### PR TITLE
refactor(ai): Send file/exercise ids based on chat session context

### DIFF
--- a/src/components/Molecules/Chatbot/FloatingChatBotWindow.tsx
+++ b/src/components/Molecules/Chatbot/FloatingChatBotWindow.tsx
@@ -1,9 +1,13 @@
-import ChatBotWindow from "@/features/Chatbot/ChatBotWindow";
+import ChatBotWindow, { type ChatBotChatType } from "@/features/Chatbot/ChatBotWindow";
 import { cn } from "@/lib/utils";
 
-type FloatingChatBotWindowProps = {outerClassName?: string};
+type FloatingChatBotWindowProps = { chatType: ChatBotChatType; targetId: string | null; outerClassName?: string };
 
-export function FloatingChatBotWindow({outerClassName}: FloatingChatBotWindowProps) {
+export function FloatingChatBotWindow({
+  outerClassName,
+  targetId,
+  chatType
+}: FloatingChatBotWindowProps) {
   return (
     <div className={cn("h-full w-full py-6 ", outerClassName)}>
       <div className="h-full min-h-0 flex flex-col border-2 border-ludoGrayLight rounded-lg">
@@ -11,8 +15,9 @@ export function FloatingChatBotWindow({outerClassName}: FloatingChatBotWindowPro
           <p>Ludo Tutor</p>
         </div>
         <ChatBotWindow
+          type={chatType}  
           className="h-full bg-ludoGrayDark pb-4 rounded-xl max-h-full"
-          currentFile={null}
+          targetId={targetId}
         />
       </div>
     </div>

--- a/src/constants/pathConstants.ts
+++ b/src/constants/pathConstants.ts
@@ -28,8 +28,8 @@ export const AI_PROJECT_STREAM_PROMPT = (
 
 export const AI_LESSON_STREAM_PROMPT = (prompt: string, exerciseId: string) => {
   const base =
-    API_PATH + `/ai/lesson/send-prompt?prompt=${encodeURIComponent(prompt)}`;
-  return base + `&fileId=${encodeURIComponent(exerciseId)}`;
+    API_PATH + `/ai/exercise/send-prompt?prompt=${encodeURIComponent(prompt)}`;
+  return base + `&exerciseId=${encodeURIComponent(exerciseId)}`;
 };
 
 export const SUBMIT_RENAME_PROJECT = API_PATH + `/project/rename`;

--- a/src/features/Chatbot/ChatBotWindow.tsx
+++ b/src/features/Chatbot/ChatBotWindow.tsx
@@ -2,17 +2,24 @@
 import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { useState } from "react";
 import { useAIStream } from "@/Hooks/Logic/AI/useAIStream";
-import { AI_PROJECT_STREAM_PROMPT } from "@/constants/pathConstants";
+import {
+  AI_LESSON_STREAM_PROMPT,
+  AI_PROJECT_STREAM_PROMPT,
+} from "@/constants/pathConstants";
 import { useAutoScrollDown } from "@/Hooks/UI/useAutoScrollDown";
 import { ChatBotConversation } from "./ChatBotConversation";
 import { ChatBotInput } from "./ChatBotInput";
 import { cn } from "@/lib/utils";
 type ChatBotProps = {
   className?: string;
-  currentFile: string | null;
+  type: ChatBotChatType
+  targetId: string | null;
 };
 
-const ChatBotWindow = ({ currentFile, className }: ChatBotProps) => {
+
+export type ChatBotChatType = "LESSON" | "PROJECT"
+
+const ChatBotWindow = ({ targetId, type, className }: ChatBotProps) => {
   const [url, setUrl] = useState<string | null>(null);
 
   const { messages, addUserMessage } = useAIStream(url);
@@ -20,7 +27,17 @@ const ChatBotWindow = ({ currentFile, className }: ChatBotProps) => {
 
   const handleSubmit = (message: PromptInputMessage) => {
     addUserMessage(message.text);
-    setUrl(AI_PROJECT_STREAM_PROMPT(message.text, currentFile));
+    switch (type) {
+      case "LESSON":
+        if (targetId != null) {
+          setUrl(AI_LESSON_STREAM_PROMPT(message.text, targetId));
+        }
+      break;
+      case "PROJECT":
+        setUrl(AI_PROJECT_STREAM_PROMPT(message.text, targetId));
+      break;
+    }
+    
   };
 
   return (

--- a/src/features/Exercise/ExerciseComponent.tsx
+++ b/src/features/Exercise/ExerciseComponent.tsx
@@ -33,7 +33,7 @@ export function ExerciseComponent({
   return (
     <>
       <div className="col-span-1 lg:col-span-4 h-full min-h-0">
-        <FloatingChatBotWindow outerClassName="pl-6 pr-30" />
+        <FloatingChatBotWindow chatType="LESSON" targetId={exercise.id} outerClassName="pl-6 pr-30" />
       </div>
 
       <div className="col-span-10 lg:col-span-4 flex flex-col gap-8 py-8 items-stretch justify-center h-full min-w-0">

--- a/src/features/Project/ProjectPage.tsx
+++ b/src/features/Project/ProjectPage.tsx
@@ -60,7 +60,7 @@ export function ProjectPage({}: ProjectPageProps) {
           />
           <div className="min-h-0 w-full h-full flex flex-col justify-end">
             <ChatBotAccordion>
-              <ChatBotWindow currentFile={currentFileId} />
+              <ChatBotWindow type="PROJECT" targetId={currentFileId} />
             </ChatBotAccordion>
           </div>
         </div>


### PR DESCRIPTION
Can now pass a "LESSON" | "PROJECT" prop to the ChatBotWindow component along with respective id, and it will send the exercise / file to the dedicated server endpoint.

Closes: #58 

<img width="1492" height="853" alt="image" src="https://github.com/user-attachments/assets/ee7a5d18-f441-46ff-95ce-1ef9a18ff4d9" />
