### PR TITLE
style(builder): Remove header from overflow y portion

### DIFF
--- a/src/features/Builder/NewBuilderLayout.tsx
+++ b/src/features/Builder/NewBuilderLayout.tsx
@@ -13,6 +13,7 @@ import { ModuleListForm } from "./Form/Module/ModuleListForm";
 import { LudoSidebar } from "@/components/Molecules/Sidebar/LudoSidebar";
 import { NewBuilderHeader } from "./UI/NewBuilderHeader";
 
+//TODO rename these
 type NewBuilderLayoutProps = {};
 
 export function NewBuilderLayout({}: NewBuilderLayoutProps) {
@@ -70,9 +71,9 @@ export function NewBuilderLayout({}: NewBuilderLayoutProps) {
           />
         </LudoSidebar>
         <SidebarInset>
-          <MainGridWrapper gridRows="SITE">
+          <MainGridWrapper className="max-h-dvh" gridRows="SITE">
             <NewBuilderHeader handleFormSubmission={handleFormSubmission} />
-            <div className="grid col-span-full h-full grid-cols-12 bg-ludoGrayDark">
+            <div className="grid col-span-full overflow-y-auto h-full grid-cols-12 bg-ludoGrayDark">
               <div className="col-start-2 py-8 h-full flex items-start justify-center col-end-12">
                 <ExerciseNodeForm
                   courseId={courseId}


### PR DESCRIPTION
- Header no longer scrolls with the page, stays in fixed position

Closes: #67 

<img width="1499" height="324" alt="image" src="https://github.com/user-attachments/assets/921994b4-09e3-48c9-b889-451c23e364f8" />
