### PR TITLE
feat(mobile header): Add interactive buttons to header

### DIFF
--- a/src/components/Molecules/Header/DesktopHeader.tsx
+++ b/src/components/Molecules/Header/DesktopHeader.tsx
@@ -1,50 +1,16 @@
-import { FireIcon } from "@heroicons/react/24/solid";
-import { navIcons } from "../../../constants/navIcons.ts";
-import { HollowSlotButton } from "../../Atoms/Button/HollowSlotButton.tsx";
-import { CommitIcon } from "../../Atoms/Icons/CustomIcon.tsx";
 import { HeaderWithBar } from "./HeaderWithBar.tsx";
-import { useStatsContext } from "../../../features/Common/StatsContext.tsx";
-import { useLocation } from "@tanstack/react-router";
-import { useModal } from "@/Hooks/UI/useModal.tsx";
-import { CoinsDialog } from "@/components/Molecules/Dialog/CoinsDialog.tsx";
-import { StreakStatsDialog } from "@/components/Molecules/Dialog/StreakStatsDialog.tsx";
-import { HollowSlotButtonGroup } from "@/components/Molecules/Group/HollowSlotButtonGroup.tsx";
 import { NavigationIconGroup } from "@/components/Organisms/NavigationIconGroup.tsx";
+import { StatsGroup } from "@/components/Organisms/StatsGroup.tsx";
 
 type DesktopHeaderProps = {};
 
 export function DesktopHeader({}: DesktopHeaderProps) {
-  const { coins, streak } = useStatsContext();
-
-  const {
-    modalOpen: coinsOpen,
-    openModal: openCoins,
-    closeModal: closeCoins,
-  } = useModal();
-  const {
-    modalOpen: streakOpen,
-    openModal: openStreak,
-    closeModal: closeStreak,
-  } = useModal();
-
   return (
     <HeaderWithBar device="Desktop">
       <div className="col-start-2 col-end-12 flex items-center justify-between">
         <NavigationIconGroup />
-
-        <HollowSlotButtonGroup>
-          <HollowSlotButton onClick={() => openCoins()}>
-            <CommitIcon className="h-5 text-pythonYellow" />
-            <p className="text-white text-sm">{coins}</p>
-          </HollowSlotButton>
-          <HollowSlotButton onClick={() => openStreak()}>
-            <FireIcon className="h-5 text-orange-400" />
-            <p className="text-sm">{streak}</p>
-          </HollowSlotButton>
-        </HollowSlotButtonGroup>
+        <StatsGroup />
       </div>
-      <CoinsDialog open={coinsOpen} close={closeCoins} />
-      <StreakStatsDialog open={streakOpen} close={closeStreak} />
     </HeaderWithBar>
   );
 }

--- a/src/components/Organisms/StatsGroup.tsx
+++ b/src/components/Organisms/StatsGroup.tsx
@@ -1,0 +1,42 @@
+import { useStatsContext } from "@/features/Common/StatsContext";
+import { useModal } from "@/Hooks/UI/useModal";
+import { HollowSlotButtonGroup } from "../Molecules/Group/HollowSlotButtonGroup";
+import { HollowSlotButton } from "../Atoms/Button/HollowSlotButton";
+import { CommitIcon } from "../Atoms/Icons/CustomIcon";
+import { FireIcon } from "@heroicons/react/24/solid";
+import { CoinsDialog } from "../Molecules/Dialog/CoinsDialog";
+import { StreakStatsDialog } from "../Molecules/Dialog/StreakStatsDialog";
+
+type StatsGroupProps = { groupClassName?: string; buttonClassName?: string };
+
+export function StatsGroup({groupClassName, buttonClassName}: StatsGroupProps) {
+  const { coins, streak } = useStatsContext();
+
+  const {
+    modalOpen: coinsOpen,
+    openModal: openCoins,
+    closeModal: closeCoins,
+  } = useModal();
+  const {
+    modalOpen: streakOpen,
+    openModal: openStreak,
+    closeModal: closeStreak,
+  } = useModal();
+
+  return (
+    <>
+      <HollowSlotButtonGroup className={groupClassName}>
+        <HollowSlotButton className={buttonClassName} onClick={() => openCoins()}>
+          <CommitIcon className="h-5 text-pythonYellow" />
+          <p className="text-white text-sm">{coins}</p>
+        </HollowSlotButton>
+        <HollowSlotButton onClick={() => openStreak()}>
+          <FireIcon className="h-5 text-orange-400" />
+          <p className="text-sm">{streak}</p>
+        </HollowSlotButton>
+      </HollowSlotButtonGroup>
+      <CoinsDialog open={coinsOpen} close={closeCoins} />
+      <StreakStatsDialog open={streakOpen} close={closeStreak} />
+    </>
+  );
+}

--- a/src/features/Module/Header/MobileModuleHeader.tsx
+++ b/src/features/Module/Header/MobileModuleHeader.tsx
@@ -6,30 +6,24 @@ import {
 import { HollowSlotButton } from "../../../components/Atoms/Button/HollowSlotButton.tsx";
 import { HeaderWithBar } from "../../../components/Molecules/Header/HeaderWithBar.tsx";
 import { useStatsContext } from "../../Common/StatsContext.tsx";
+import { StatsGroup } from "@/components/Organisms/StatsGroup.tsx";
+import { router } from "@/routes/router.tsx";
+import { ludoNavigation } from "@/routes/ludoNavigation.tsx";
 
 type ModuleHeaderProps = {};
 
 export function ModuleHeader({}: ModuleHeaderProps) {
-  const { coins, streak } = useStatsContext();
-
   return (
     <HeaderWithBar device="Mobile">
       <div className="col-start-2 col-end-12 flex py-2 items-center justify-between">
         <div>
-          <HollowSlotButton>
+          <HollowSlotButton onClick={() => router.navigate(ludoNavigation.courseRoot())}>
             <PythonIcon className="h-6" />
             <ArrowsRightLeftIcon className="h-6 text-white" />
           </HollowSlotButton>
         </div>
-        <div className="flex w-full text-white justify-end gap-2 items-center">
-          <HollowSlotButton>
-            <CommitIcon className="h-7 text-pythonYellow" />
-            <p>{coins}</p>
-          </HollowSlotButton>
-          <HollowSlotButton>
-            <FireIcon className="h-7 text-orange-400" />
-            <p>{streak}</p>
-          </HollowSlotButton>
+        <div className="flex w-full text-white justify-end items-center">
+          <StatsGroup groupClassName="gap-4" />
         </div>
       </div>
     </HeaderWithBar>


### PR DESCRIPTION
- Extracted stats group with dialogs into own component

Closes: #76 