### PR TITLE
feat(spinner): Add spinner component and implement it in monaco editor

### DIFF
--- a/src/components/Molecules/Progress/LudoSpinner.tsx
+++ b/src/components/Molecules/Progress/LudoSpinner.tsx
@@ -1,0 +1,32 @@
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+type LudoSpinnerProps = {
+  wide?: boolean;
+  children?: ReactNode;
+  className?: string;
+  spinnerClassName?: string;
+};
+
+export function LudoSpinner({
+  wide = false,
+  className,
+  children,
+  spinnerClassName,
+}: LudoSpinnerProps) {
+  const wideStyle = wide ? "w-full h-full" : "";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col justify-center items-center",
+        wideStyle,
+        className
+      )}
+    >
+      <Spinner className={spinnerClassName} />
+      {children && children}
+    </div>
+  );
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }

--- a/src/features/Project/Editor/ProjectEditor.tsx
+++ b/src/features/Project/Editor/ProjectEditor.tsx
@@ -1,6 +1,7 @@
 import { useMonacoTheme } from "@/Hooks/UI/useMonacoTheme";
 import type * as monacoTypes from "monaco-editor";
 import Editor from "@monaco-editor/react";
+import { LudoSpinner } from "@/components/Molecules/Progress/LudoSpinner";
 type ProjectEditorProps = {
   path: string;
   language: string;
@@ -41,6 +42,13 @@ export function ProjectEditor({
       value={value}
       onChange={(v) => onChange(v ?? "")}
       beforeMount={beforeMount}
+      loading={
+        <LudoSpinner
+          className="text-ludoLightPurple"
+          spinnerClassName="h-10 w-10"
+          wide
+        />
+      }
       onMount={handleMount}
       language={language}
       options={editorOptions}


### PR DESCRIPTION
- There is now a loading spinner with an optional wide prop to fill the container. 
- Editor has spinner (see image)

Closes: #53 

<img width="1498" height="849" alt="image" src="https://github.com/user-attachments/assets/b37a763a-71be-4e21-848f-8a796f9e21a9" />
