### PR TITLE
feat(demo user): Add demo user route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "embla-carousel-react": "^8.6.0",
         "event-source-polyfill": "^1.0.31",
         "howler": "^2.2.4",
+        "js-cookie": "^3.0.5",
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.548.0",
         "motion": "^12.23.24",
@@ -63,6 +64,7 @@
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@types/howler": "^2.2.12",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^24.9.2",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
@@ -3750,6 +3752,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6660,6 +6669,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "embla-carousel-react": "^8.6.0",
     "event-source-polyfill": "^1.0.31",
     "howler": "^2.2.4",
+    "js-cookie": "^3.0.5",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.548.0",
     "motion": "^12.23.24",
@@ -65,6 +66,7 @@
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@types/howler": "^2.2.12",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^24.9.2",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/src/Hooks/Queries/Definitions/queries.ts
+++ b/src/Hooks/Queries/Definitions/queries.ts
@@ -7,7 +7,7 @@ import {
   userBatcher,
   userCoinsBatcher,
 } from "../Batcher/batchers";
-
+import Cookies from "js-cookie";
 import type { LudoModule } from "../../../Types/Catalog/LudoModule";
 import type { LudoLesson } from "../../../Types/Catalog/LudoLesson";
 import type { CourseProgress } from "../../../Types/Progress/CourseProgress";
@@ -88,6 +88,7 @@ export const qo = {
     queryOptions({
       queryKey: qk.currentUser(),
       queryFn: () => ludoGet<LudoUser>(AUTH_ME, true),
+      enabled: () => Boolean(Cookies.get("jwt")),
       staleTime: 60_000,
       retry: false,
     }),

--- a/src/Hooks/Queries/Mutations/useGoogleAuthEntry.tsx
+++ b/src/Hooks/Queries/Mutations/useGoogleAuthEntry.tsx
@@ -14,6 +14,8 @@ export function useGoogleAuthEntry() {
     onSuccess: async (codeResponse) => {
       console.log(codeResponse);
 
+      console.log("Calling post")
+
       const { user, userCoins, userStreak }: LoginUserResponse = await ludoPost(
         GOOGLE_LOGIN,
         { code: codeResponse.code },

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,1 +1,2 @@
 export const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+export const DEMO_AUTH_TOKEN = import.meta.env.VITE_DEMO_AUTH_TOKEN

--- a/src/constants/pathConstants.ts
+++ b/src/constants/pathConstants.ts
@@ -1,9 +1,13 @@
+import { DEMO_AUTH_TOKEN } from "./env";
+
 export const API_URL = "http://localhost:8080";
 export const API_PREFIX = "/api/v1";
 export const API_PATH = API_URL + API_PREFIX;
 
 export const GET_COURSE_TREE = (courseId: string) =>
   API_PATH + `/catalog/courses/${courseId}/tree`;
+
+export const DEMO_LOGIN = API_PATH + `/auth/demo-login?token=${DEMO_AUTH_TOKEN}`
 
 export const SUBMIT_LESSON = API_PATH + `/progress/completion/submit`;
 export const RESET_COURSE_PROGRESS = (courseId: string) =>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,6 +2,8 @@ export const RP_INDEX = `/`;
 
 export const RP_COURSE = `/`;
 
+export const RP_DEMO = `/demo`
+
 export const RP_BUILD = `/build/course/$courseId`;
 
 export const RP_BUILD_MODULE = `${RP_BUILD}/module/$moduleId`;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -22,6 +22,7 @@ import {
   RP_ONBOARDING_START,
   RP_PLAYGROUND,
   RP_PROJECT,
+  RP_DEMO,
 } from "../constants/routes.ts";
 import { LessonLayout } from "../Layouts/LessonLayout.tsx";
 import { QueryClient } from "@tanstack/react-query";
@@ -44,7 +45,6 @@ import {
   type StageKey,
 } from "@/Types/Onboarding/OnboardingSteps.ts";
 import { OnboardingStagePage } from "@/features/Onboarding/OnboardingStagePage.tsx";
-import { ProjectPage } from "@/features/Project/ProjectPage.tsx";
 import { PlaygroundPage } from "@/features/Playground/PlaygroundPage.tsx";
 import { playgroundLoader, projectLoader } from "./Loaders/playgroundLoader.ts";
 import { BuilderRedirectPage } from "@/features/Builder/BuilderRedirectPage.tsx";
@@ -53,6 +53,7 @@ import { ErrorPage } from "@/features/Error/ErrorPage.tsx";
 import { DesktopOnlyPage } from "@/Layouts/ErrorPage/DesktopOnlyPage.tsx";
 import { LessonPage } from "@/features/Exercise/LessonPage.tsx";
 import { ProjectLayout } from "@/Layouts/ProjectLayout.tsx";
+import { DEMO_LOGIN } from "@/constants/pathConstants.ts";
 
 export const queryClient = new QueryClient();
 
@@ -85,6 +86,21 @@ const authedRoute = createRoute({
     if (!currentCourseId || !userPreferences) {
       throw redirect({ to: RP_ONBOARDING_START, replace: true });
     }
+  },
+});
+
+const demoLoginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: RP_DEMO,
+  beforeLoad: async () => {
+    await fetch(DEMO_LOGIN, {
+      method: "GET",
+      credentials: "include",
+    });
+    await queryClient.invalidateQueries();
+    await queryClient.ensureQueryData(qo.currentUser());
+
+    throw redirect({ to: RP_COURSE });
   },
 });
 
@@ -159,30 +175,6 @@ export const onboardingStageRoute = createRoute({
   }),
   component: OnboardingStagePage,
 });
-
-// export const profileMeRoute = createRoute({
-//   getParentRoute: () => defaultSectionRoute,
-//   path: RP_ME,
-//   loader: async ({ location }) => {
-//     const userId = "1";
-//     const target = `/profile/${userId}`;
-//     if (location.pathname !== target) {
-//       throw redirect({
-//         to: RP_PROFILE,
-//         params: { userId },
-//         replace: true,
-//       });
-//     }
-//     return null;
-//   },
-// });
-
-// export const profileByIdRoute = createRoute({
-//   getParentRoute: () => defaultSectionRoute,
-//   path: RP_PROFILE,
-//   staticData: { headerTitle: "Profile" },
-//   component: ProfilePage,
-// });
 
 export const modulesRedirectRoute = createRoute({
   getParentRoute: () => siteRoute,
@@ -270,6 +262,7 @@ export const lessonRoute = createRoute({
 });
 
 const routeTree = rootRoute.addChildren([
+  demoLoginRoute,
   authedRoute.addChildren([
     onboardingRoute.addChildren([onboardingStageRoute]),
     siteRoute.addChildren([


### PR DESCRIPTION
- Can log in with a demo account using the `/demo` path.
- Sends a GET request to the backend with a demo JWT and backend returns session cookie with user.
- Demo token is set in the environment variables.