### PR TITLE
fix(builder module): Fix red status light dissapearing on collapse expanded

### DIFF
--- a/src/Types/Zod/SnapshotSchema/ModuleSnapshotSchema.ts
+++ b/src/Types/Zod/SnapshotSchema/ModuleSnapshotSchema.ts
@@ -26,6 +26,15 @@ export const ModuleSnapshotSchema = z
       return null;
     };
 
+    if (m.title.length <= 0) {
+      hasError = true;
+      ctx.addIssue({
+        code: "custom",
+        path: ["title"],
+        message: `Title for the module must be non-empty`
+      })
+    }
+
     const dupId = dup(ids);
     if (dupId) {
       hasError = true;
@@ -39,6 +48,7 @@ export const ModuleSnapshotSchema = z
     const badLesson = m.lessons.findIndex(
       (lesson) => !LessonSnapSchema.safeParse(lesson).success
     );
+
     if (badLesson !== -1) {
       hasError = true;
       ctx.addIssue({

--- a/src/features/Builder/Form/Module/ModuleNodeForm.tsx
+++ b/src/features/Builder/Form/Module/ModuleNodeForm.tsx
@@ -7,7 +7,6 @@ import { EditNodeDialog } from "@/components/Molecules/Dialog/EditNodeDialog";
 import { ExpandCollapsibleButtonProps } from "@/components/Atoms/Button/ExpandCollapsibleButton";
 import { LessonListForm } from "../Lesson/LessonListForm";
 import { StatusButtonField } from "@/components/Atoms/Status/StatusButtonField";
-import { SelectModuleButton } from "../../UI/Button/SelectModuleButton";
 import { BuilderNodeWrapper } from "@/components/Molecules/Sidebar/BuilderNodeWrapper";
 
 export const ModuleNodeForm = withForm({
@@ -36,7 +35,6 @@ export const ModuleNodeForm = withForm({
     return (
       <form.Field name={`modules[${index}]`}>
         {(field) => {
-          
           const modules = form.state.values.modules;
           const module = field.state.value;
           const isExpanded = !!module.isExpanded;
@@ -72,7 +70,19 @@ export const ModuleNodeForm = withForm({
                     {(moduleField) => {
                       const hasError =
                         moduleField.state.meta.errors?.[0]?.message;
-                      return <StatusButtonField hasError={!!hasError} />;
+                      return (
+                        <form.AppField name={`modules[${index}].lessons`}>
+                          {(lessonsField) => {
+                            const lessonsHaveError =
+                              lessonsField.state.meta.errors?.[0]?.message;
+                            return (
+                              <StatusButtonField
+                                hasError={!!hasError || !!lessonsHaveError}
+                              />
+                            );
+                          }}
+                        </form.AppField>
+                      );
                     }}
                   </form.AppField>
                 </BuilderNode>


### PR DESCRIPTION
- Collapsed modules will now keep their childrens errors 
- Fixed by also checking the modules lessons for errors in its status conditions
- Module now shows error if its title is empty

Closes: #102 

<img width="444" height="309" alt="image" src="https://github.com/user-attachments/assets/55e76467-644b-47fd-a43e-16bc4a4b6854" />
