### PR TITLE
refactor(dialogs): Add exit popover button & re-style create project dialog

### DIFF
--- a/apps/admin/src/features/BuilderHub/Components/Dialog/CreateCourseDialog.tsx
+++ b/apps/admin/src/features/BuilderHub/Components/Dialog/CreateCourseDialog.tsx
@@ -49,6 +49,7 @@ export function CreateCourseDialog({
         </DialogHeader>
 
         <InputWrapper>
+          
           <InputTitle>Course Name</InputTitle>
           <Input
             placeholder={courseName}

--- a/apps/web/src/constants/ludoNavigation.tsx
+++ b/apps/web/src/constants/ludoNavigation.tsx
@@ -23,8 +23,7 @@ import { Route as completionRoute } from "@/routes/_app/completion/$courseId/$mo
 
 // ONBOARDING
 import { Route as onboardingStageRoute } from "@/routes/_app/onboarding.$stage.tsx";
-import type { StageKey } from "@/features/Onboarding/Steps/OnboardingSteps";
-import type { LessonSubmission } from "@ludocode/types";
+import type { LessonSubmission, StageKey } from "@ludocode/types";
 
 export const ludoNavigation = {
   auth: {

--- a/apps/web/src/features/Auth/Components/Input/AuthInputField.tsx
+++ b/apps/web/src/features/Auth/Components/Input/AuthInputField.tsx
@@ -10,6 +10,8 @@ type AuthInputFieldProps = {
   placeHolder?: string;
   isProtected?: boolean;
   errorMsg?: string;
+  ring?: boolean;
+  variant?: "default" | "alt";
   isError?: boolean;
 };
 
@@ -19,23 +21,33 @@ export function AuthInputField({
   title,
   placeHolder,
   isProtected,
+  ring = false,
   errorMsg = "Required",
+  variant = "default",
   isError,
 }: AuthInputFieldProps) {
   const errorStyle = isError ? "border border-red-400" : "";
+  const ringStyle = ring ? "" : "focus:ring-0 focus-visible:ring-0";
+  const variantStyle =
+    variant == "default"
+      ? "border-transparent"
+      : "border-3 border-ludoAltAccent focus:border-ludoAltAccent focus-visible:border-ludoAltAccent font-bold";
+
   const [isHidden, setIsHidden] = useState<boolean>(isProtected ?? false);
 
   return (
-    <div className="w-full text-ludoAltText flex flex-col gap-2">
+    <div className="w-full text-ludoAltText items-start flex flex-col gap-2">
       {title && <p className="text-sm">{title}</p>}
-      <div className="relative">
+      <div className="relative w-full">
         <Input
           type={isHidden ? "password" : "text"}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           className={cn(
             "bg-ludoGrayLight placeholder:text-ludoGray pr-10 h-12 border border-transparent text-white",
-            errorStyle
+            ringStyle,
+            errorStyle,
+            variantStyle
           )}
           placeholder={placeHolder}
         />
@@ -45,7 +57,11 @@ export function AuthInputField({
             onClick={() => setIsHidden((v) => !v)}
             className="absolute hover:cursor-pointer h-4 w-4 z-10 right-4 top-1/2 -translate-y-1/2"
           >
-            {isHidden ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4"/>}
+            {isHidden ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
           </button>
         )}
       </div>

--- a/apps/web/src/features/Hub/ModuleHub/Components/Path/PathPopover.tsx
+++ b/apps/web/src/features/Hub/ModuleHub/Components/Path/PathPopover.tsx
@@ -1,9 +1,9 @@
-
 import type { ReactElement } from "react";
 import { XSquareIcon } from "lucide-react";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button.tsx";
 import { LudoPopover } from "@ludocode/design-system/widgets/ludo-popover.tsx";
 import type { LessonStatus, LudoLesson } from "@ludocode/types";
+import { PopoverClose } from "@radix-ui/react-popover";
 type PathPopoverProps = {
   trigger: ReactElement;
   lesson: LudoLesson;
@@ -46,7 +46,11 @@ export function PathPopover({
         </p>
       </div>
       <div className="flex flex-col items-end justify-between">
-        <XSquareIcon className="text-ludoLightPurple hover:cursor-pointer h-4 w-4" />
+        <PopoverClose asChild>
+          <button type="button" aria-label="Close">
+            <XSquareIcon className="text-ludoLightPurple hover:cursor-pointer h-4 w-4" />
+          </button>
+        </PopoverClose>
         <LudoButton
           onClick={() => goToLesson()}
           className="h-7 w-20 lg:w-26 rounded-sm"

--- a/apps/web/src/features/Hub/ProjectHub/Components/Card/ProjectCard.tsx
+++ b/apps/web/src/features/Hub/ProjectHub/Components/Card/ProjectCard.tsx
@@ -7,12 +7,12 @@ import { useRouter } from "@tanstack/react-router";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button.tsx";
 import { CustomIcon } from "@ludocode/design-system/primitives/custom-icon.tsx";
 import dayjs from "dayjs";
+import { router } from "@/main";
 
 type ProjectCardProps = { project: ProjectSnapshot };
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const { projectId, projectName, projectLanguage, updatedAt } = project;
-  const router = useRouter();
 
   const { handleRenameProject, handleDeleteProject } =
     useModifyProject(projectId);

--- a/apps/web/src/features/Hub/ProjectHub/Components/Dialog/CreateProjectDialog.tsx
+++ b/apps/web/src/features/Hub/ProjectHub/Components/Dialog/CreateProjectDialog.tsx
@@ -1,15 +1,11 @@
 import { DialogTitle } from "@ludocode/external/ui/dialog.tsx";
-import { Input } from "@ludocode/external/ui/input.tsx";
-import { Button } from "@ludocode/external/ui/button.tsx";
 import type { LanguageType } from "@ludocode/types/Project/LanguageType.ts";
 import { useState, type ReactNode } from "react";
 import { useCreateProject } from "@/hooks/Queries/Mutations/useCreateProject.tsx";
 import { Spinner } from "@ludocode/external/ui/spinner.tsx";
 import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog.tsx";
-import {
-  InputWrapper,
-  InputTitle,
-} from "@ludocode/design-system/primitives/input";
+import { InputWrapper } from "@ludocode/design-system/primitives/input";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
 
 type CreateProjectDialogProps = {
   open: boolean;
@@ -65,39 +61,28 @@ export function CreateProjectDialog({
       </DialogTitle>
 
       <InputWrapper>
-        <InputTitle>Project name</InputTitle>
-        <Input
-          placeholder={projectName}
-          value={projectName}
-          onChange={(e) => setProjectName(e.target.value)}
-        />
-      </InputWrapper>
-
-      <InputWrapper>
-        <InputTitle>Project type</InputTitle>
-        <div className="flex gap-4">
+        <div className="flex w-full gap-4">
           {possibleOptions.map((option) => (
-            <Button
+            <LudoButton
               onClick={() => setProjectLanguage(option)}
-              className={`${
-                projectLanguage == option ? "border border-ludoLightPurple" : ""
-              }`}
+              variant={projectLanguage == option ? "alt" : "white"}
             >
-              {option}
-            </Button>
+              {option[0].toUpperCase() + option.slice(1)}
+            </LudoButton>
           ))}
         </div>
       </InputWrapper>
 
       <div className="py-2 mt-2 flex gap-2 justify-center items-center">
-        <Button
-          variant={isSubmitLoading ? "disabled" : "default"}
+        <LudoButton
+          disabled={isSubmitLoading}
+          variant="alt"
           onClick={() => submitProject()}
           className="w-full flex"
         >
           Create Project
           {isSubmitLoading && <Spinner className="text-ludoLightPurple" />}
-        </Button>
+        </LudoButton>
       </div>
     </LudoDialog>
   );


### PR DESCRIPTION
## Changes

- Removed project name from project creation dialog (user can set it after creation)
- Switched from shadcn button to LudoButton for buttons
- Implemented close popover button in PathPopover

Closes: #198 

## Screenshots

### Changed Create Project Dialog
<img width="1032" height="610" alt="image" src="https://github.com/user-attachments/assets/60017a67-f0e1-4ff3-b360-e854cd97ccba" />
