### PR TITLE
style(onboarding): Extract onboarding options into WideOnboardingOption

### DIFF
--- a/apps/web/src/features/Onboarding/Components/WideOnboardingOption.tsx
+++ b/apps/web/src/features/Onboarding/Components/WideOnboardingOption.tsx
@@ -1,0 +1,24 @@
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import type { ReactNode } from "react";
+
+type WideOnboardingOptionProps = {
+  onClick: () => void;
+  isSelected: boolean;
+  children: ReactNode;
+};
+
+export function WideOnboardingOption({
+  onClick,
+  isSelected,
+  children,
+}: WideOnboardingOptionProps) {
+  return (
+    <LudoButton
+      onClick={onClick}
+      variant={isSelected ? "alt" : "default"}
+      className={`p-6 min-h-30 flex flex-col items-center gap-2 justify-center rounded-2xl`}
+    >
+      {children}
+    </LudoButton>
+  );
+}

--- a/apps/web/src/features/Onboarding/Steps/OnboardingStepComponents.tsx
+++ b/apps/web/src/features/Onboarding/Steps/OnboardingStepComponents.tsx
@@ -2,6 +2,8 @@ import type { CareerType } from "@ludocode/types";
 import { useOnboardingContext } from "../Context/OnboardingContext";
 import { OnboardingStageShell } from "../Components/Zone/OnboardingStageShell";
 import { AuthInputField } from "@/features/Auth/Components/Input/AuthInputField";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import { WideOnboardingOption } from "../Components/WideOnboardingOption";
 
 export function CareerChoiceStep() {
   const { content, draftApi } = useOnboardingContext();
@@ -15,17 +17,15 @@ export function CareerChoiceStep() {
   return (
     <OnboardingStageShell title={stepTitles.career}>
       {careerContent.map((cContent) => (
-        <div
+        <WideOnboardingOption
+          isSelected={cContent.careerType == draft.career}
           onClick={() => setDraft({ career: cContent.careerType })}
-          className={`p-6 hover:cursor-pointer ${selectedColor(
-            cContent.careerType
-          )} min-h-40 flex flex-col items-center gap-2 justify-center rounded-2xl bg-ludoGrayLight`}
         >
           <h1 className="text-white text-xl font-bold">{cContent.title}</h1>
           <p className="text-white">
             Top languages: <span className="font-bold">{cContent.topPath}</span>
           </p>
-        </div>
+        </WideOnboardingOption>
       ))}
     </OnboardingStageShell>
   );
@@ -37,21 +37,16 @@ export function CourseChoiceStep() {
   const { courseContent, stepTitles } = content;
 
   const selectedCourse = draft.course ?? null;
-  const isSelected = (courseId: string) => courseId == selectedCourse;
 
   return (
     <OnboardingStageShell title={stepTitles.course}>
       {courseContent.map((cContent) => (
-        <div
+        <WideOnboardingOption
+          isSelected={cContent.courseId == selectedCourse}
           onClick={() => setDraft({ course: cContent.courseId })}
-          className={`p-6 hover:cursor-pointer ${
-            isSelected(cContent.courseId)
-              ? "border-2 border-ludoLightPurple"
-              : ""
-          } min-h-40 flex flex-col items-center justify-center rounded-2xl bg-ludoGrayLight`}
         >
           <h1 className="text-white text-xl font-bold">{cContent.title}</h1>
-        </div>
+        </WideOnboardingOption>
       ))}
     </OnboardingStageShell>
   );
@@ -63,19 +58,16 @@ export function HasExperienceStep() {
   const { previousExperienceContent, stepTitles } = content;
 
   const selectedExperience = draft.experience;
-  const isSelected = (value: boolean) => value === selectedExperience;
 
   return (
     <OnboardingStageShell title={stepTitles.experience}>
       {previousExperienceContent.map((peContent) => (
-        <div
+        <WideOnboardingOption
           onClick={() => setDraft({ experience: peContent.value })}
-          className={`p-6 hover:cursor-pointer ${
-            isSelected(peContent.value) ? "border-2 border-ludoLightPurple" : ""
-          } min-h-40 flex flex-col items-center justify-center rounded-2xl bg-ludoGrayLight`}
+          isSelected={peContent.value == selectedExperience}
         >
           <h1 className="text-white text-xl font-bold">{peContent.content}</h1>
-        </div>
+        </WideOnboardingOption>
       ))}
     </OnboardingStageShell>
   );


### PR DESCRIPTION
## Changes

- Extracted repeating option buttons in onboarding into `WideOnboardingOption`

## Screenshots

<img width="350" height="376" alt="image" src="https://github.com/user-attachments/assets/e87f819e-2f7c-4bac-8310-201f7ab61581" />
