### PR TITLE
feat(dialog): Add optional confirmation prompt to warning dialog

### DIFF
--- a/apps/web/src/features/Auth/Components/DeleteAccountButton.tsx
+++ b/apps/web/src/features/Auth/Components/DeleteAccountButton.tsx
@@ -1,8 +1,13 @@
 import { useDeleteAccount } from "@/hooks/Queries/Mutations/useDeleteAccount";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
 import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog";
+import type { DestructiveActionConfirmation } from "@ludocode/design-system/templates/dialog/WarningDialog";
 
-export function DeleteAccountButton() {
+type DeleteAccountButtonProps = {
+  username: string;
+};
+
+export function DeleteAccountButton({ username }: DeleteAccountButtonProps) {
   const deleteUserMutation = useDeleteAccount();
 
   const handleDeleteAccount = () => {
@@ -10,10 +15,15 @@ export function DeleteAccountButton() {
     deleteUserMutation.mutate();
   };
 
+  const confirmation: DestructiveActionConfirmation = {
+    confirmationValue: username,
+    confirmationText: `type ${username} to confirm`,
+  };
+
   return (
     <DeleteDialog
       targetName="your account"
-      canDelete
+      destructiveConfirmation={confirmation}
       onClick={() => handleDeleteAccount()}
     >
       <LudoButton variant="danger">Delete Account</LudoButton>

--- a/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
@@ -16,7 +16,7 @@ import { ludoNavigation } from "@/constants/ludoNavigation";
 
 export function AccountSettingsPage() {
   const { data: user } = useSuspenseQuery(qo.currentUser());
-  const { avatarIndex, avatarVersion, createdAt } = user;
+  const { avatarIndex, avatarVersion, createdAt, displayName } = user;
   const joinTime = dayjs(createdAt).format("MMMM DD, YYYY");
   const userPfpSrc = getUserAvatar(avatarVersion, avatarIndex);
   return (
@@ -47,7 +47,7 @@ export function AccountSettingsPage() {
 
         <ProfileCardContainer className="gap-5" header="DANGER ZONE">
           <LogoutButton />
-          <DeleteAccountButton />
+          <DeleteAccountButton username={displayName!!} />
         </ProfileCardContainer>
       </div>
     </div>

--- a/packages/design-system/templates/dialog/WarningDialog.tsx
+++ b/packages/design-system/templates/dialog/WarningDialog.tsx
@@ -1,13 +1,20 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
 import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
 import { DialogDescription, DialogTitle } from "@ludocode/external/ui/dialog";
+import { Input } from "@ludocode/external/ui/input";
+
+export type DestructiveActionConfirmation = {
+  confirmationText: string;
+  confirmationValue: string;
+};
 
 type WarningDialogProps = {
   title: string;
   buttonText: string;
   subtitle?: string;
   onClick: () => void;
+  destructiveConfirmation?: DestructiveActionConfirmation;
   children: ReactNode;
 };
 
@@ -17,7 +24,18 @@ export function WarningDialog({
   subtitle,
   onClick,
   buttonText,
+  destructiveConfirmation,
 }: WarningDialogProps) {
+  const [confirmationValue, setConfirmationValue] = useState("");
+
+  const canClick =
+    !destructiveConfirmation ||
+    confirmationValue == destructiveConfirmation.confirmationValue;
+  const handleClick = () => {
+    if (!canClick) return;
+    onClick();
+  };
+
   return (
     <LudoDialog asChild={false} trigger={children}>
       <DialogTitle className="text-white">{title}</DialogTitle>
@@ -27,10 +45,20 @@ export function WarningDialog({
         </DialogDescription>
       )}
 
+      {destructiveConfirmation && (
+        <>
+          <DialogDescription className="text-white code font-bold">
+            type <span className="text-ludo-danger">{destructiveConfirmation.confirmationValue}</span>  to confirm
+          </DialogDescription>
+          <Input className="text-ludoAltText" onChange={(e) => setConfirmationValue(e.target.value)}/>
+        </>
+      )}
+
       <LudoButton
         className="w-full h-10"
         variant="danger"
-        onClick={() => onClick()}
+        disabled={!canClick}
+        onClick={() => handleClick()}
       >
         {buttonText}
       </LudoButton>

--- a/packages/design-system/templates/dialog/delete-dialog.tsx
+++ b/packages/design-system/templates/dialog/delete-dialog.tsx
@@ -1,9 +1,12 @@
-import { WarningDialog } from "@ludocode/design-system/templates/dialog/WarningDialog";
+import {
+  DestructiveActionConfirmation,
+  WarningDialog,
+} from "@ludocode/design-system/templates/dialog/WarningDialog";
 import type { ReactNode } from "react";
 
 type DeleteDialogProps = {
   targetName: string;
-  canDelete: boolean;
+  destructiveConfirmation?: DestructiveActionConfirmation;
   onClick: () => void;
   children: ReactNode;
 };
@@ -11,6 +14,7 @@ type DeleteDialogProps = {
 export function DeleteDialog({
   onClick,
   targetName,
+  destructiveConfirmation,
   children,
 }: DeleteDialogProps) {
   const title = `Are you sure you want to delete ${targetName}?`;
@@ -19,6 +23,7 @@ export function DeleteDialog({
     <WarningDialog
       onClick={onClick}
       title={title}
+      destructiveConfirmation={destructiveConfirmation}
       subtitle="This action is irreversible"
       buttonText="Delete"
     >


### PR DESCRIPTION
## Changes

- Added optional property to `WarningDialog` and `DeleteDialog` where a user must enter the value to confirm destructive action
- Implemented destructive confirmation on delete account action

## Screenshots
<img width="365" height="743" alt="image" src="https://github.com/user-attachments/assets/e650ba98-638b-4086-8a34-dcbdf9c9066d" />
<img width="362" height="743" alt="image" src="https://github.com/user-attachments/assets/423c3f5a-0a99-4e44-8c60-bdcf1c410805" />
