### PR TITLE
feat(preferences): Add update preferences call & mutation

### DIFF
--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/FeatureToggleCard.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/FeatureToggleCard.tsx
@@ -1,10 +1,15 @@
 import { BotIcon, Volume2Icon } from "lucide-react";
 import { StatsCard } from "./StatsCard";
-import { useState } from "react";
 
-export function FeatureToggleGroup() {
-  const [audioEnabled, setAudioEnabled] = useState(true);
-  const [aiEnabled, setAiEnabled] = useState(true);
+type FeatureToggleGroupProps = {
+  audioEnabled: boolean;
+  setAudioEnabled: (value: boolean) => void;
+  aiEnabled: boolean;
+  setAiEnabled: (value: boolean) => void;
+};
+
+export function FeatureToggleGroup({audioEnabled, setAudioEnabled, aiEnabled, setAiEnabled}: FeatureToggleGroupProps) {
+
 
   return (
     <div className="w-full flex justify-between gap-4">

--- a/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
@@ -1,6 +1,5 @@
 import { qo } from "@/hooks/Queries/Definitions/queries";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { UserCard } from "../Components/Card/UserCard";
 import { FeatureToggleGroup } from "../Components/Card/FeatureToggleCard";
 import { ProfileCardContainer } from "../Components/Card/ProfileCardContainer";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
@@ -8,37 +7,66 @@ import { AICreditBalanceCard } from "../Components/Card/AICreditBalanceCard";
 import { Avatar } from "@ludocode/design-system/primitives/avatar";
 import { getUserAvatar } from "@/constants/avatars/avatars";
 import dayjs from "dayjs";
-import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog";
 import { DeleteAccountButton } from "@/features/Auth/Components/DeleteAccountButton";
 import { LogoutButton } from "@/features/Auth/Components/LogoutButton";
 import { router } from "@/main";
 import { ludoNavigation } from "@/constants/ludoNavigation";
+import { useState } from "react";
+import { useEditPreferences } from "@/hooks/Queries/Mutations/useEditPreferences";
+import type { TogglePreferencesRequest } from "@ludocode/types";
 
 export function AccountSettingsPage() {
   const { data: user } = useSuspenseQuery(qo.currentUser());
+  const { data: preferences } = useSuspenseQuery(qo.preferences());
   const { avatarIndex, avatarVersion, createdAt, displayName } = user;
   const joinTime = dayjs(createdAt).format("MMMM DD, YYYY");
   const userPfpSrc = getUserAvatar(avatarVersion, avatarIndex);
+
+  const [audioEnabled, setAudioEnabled] = useState(preferences.audioEnabled);
+  const [aiEnabled, setAiEnabled] = useState(preferences.aiEnabled);
+
+  const editPreferencesMutation = useEditPreferences();
+
+  const handleSubmission = () => {
+    if (editPreferencesMutation.isPending) return;
+    if (
+      audioEnabled == preferences.audioEnabled &&
+      aiEnabled == preferences.aiEnabled
+    ) {
+      router.navigate(ludoNavigation.hub.profile.toProfile(user.id));
+    } else {
+      const submission: TogglePreferencesRequest = {
+        aiEnabled: aiEnabled,
+        audioEnabled: audioEnabled,
+      };
+      editPreferencesMutation.mutate(submission);
+    }
+  };
+
   return (
     <div className="col-span-full px-4 relative lg:col-span-6 flex flex-col gap-2 lg:gap-0 lg:items-center h-full min-h-0 justify-start min-w-0">
       <div className="w-full flex gap-4 py-4">
         <Avatar className="h-20 w-20" src={userPfpSrc} />
         <div className="flex flex-col gap-1">
           <h2 className=" text-2xl lg:text-2xl">{user.displayName}</h2>
-          <h3 className="lg:text-lg text-md">Joined: January 20, 2026</h3>
+          <h3 className="lg:text-lg text-md">{joinTime}</h3>
         </div>
       </div>
       <div className="w-full h-full flex flex-col gap-5">
         <LudoButton
-          onClick={() =>
-            router.navigate(ludoNavigation.hub.profile.toProfile(user.id))
-          }
+          isLoading={editPreferencesMutation.isPending}
+          onClick={() => handleSubmission()}
           variant="alt"
         >
           Save & Exit
         </LudoButton>
         <ProfileCardContainer header="PREFERENCES">
-          <FeatureToggleGroup />
+          <FeatureToggleGroup
+            audioEnabled={audioEnabled}
+            setAudioEnabled={setAudioEnabled}
+            aiEnabled={aiEnabled}
+            setAiEnabled={setAiEnabled}
+          />
         </ProfileCardContainer>
 
         <ProfileCardContainer header="AI">

--- a/apps/web/src/hooks/Queries/Definitions/mutations.ts
+++ b/apps/web/src/hooks/Queries/Definitions/mutations.ts
@@ -18,7 +18,12 @@ import {
 } from "@ludocode/api/fetcher";
 import { api } from "@/constants/api/api";
 import { logout } from "@/constants/api/logout";
-import type { EditProfileRequest, LudoUser } from "@ludocode/types";
+import type {
+  TogglePreferencesRequest,
+  UserPreferences,
+  EditProfileRequest,
+  LudoUser,
+} from "@ludocode/types";
 
 export interface ChangeCourseVariables {
   newCourseId: string;
@@ -112,6 +117,18 @@ export const mutations = {
       mutationKey: ["submitOnboarding"],
       mutationFn: (variables) =>
         ludoPut<OnboardingResponse, OnboardingSubmission>(
+          api.preferences.base,
+          variables,
+          true,
+        ),
+    });
+  },
+
+  editPreferences: () => {
+    return mutationOptions<UserPreferences, Error, TogglePreferencesRequest>({
+      mutationKey: ["editPreferences"],
+      mutationFn: (variables) =>
+        ludoPatch<UserPreferences, TogglePreferencesRequest>(
           api.preferences.base,
           variables,
           true,

--- a/apps/web/src/hooks/Queries/Mutations/useEditPreferences.tsx
+++ b/apps/web/src/hooks/Queries/Mutations/useEditPreferences.tsx
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { mutations } from "@/hooks/Queries/Definitions/mutations.ts";
+import { qk } from "../Definitions/qk";
+import { router } from "@/main";
+import { ludoNavigation } from "@/constants/ludoNavigation";
+
+export function useEditPreferences() {
+
+    const qc = useQueryClient()
+
+    return useMutation({
+        ...mutations.editPreferences(),
+        onSuccess: (payload) => {
+            qc.setQueryData(qk.preferences(), payload)
+            router.navigate(ludoNavigation.hub.profile.toProfile(payload.userId))
+        }
+    })
+
+}

--- a/packages/design-system/templates/dialog/WarningDialog.tsx
+++ b/packages/design-system/templates/dialog/WarningDialog.tsx
@@ -48,9 +48,16 @@ export function WarningDialog({
       {destructiveConfirmation && (
         <>
           <DialogDescription className="text-white code font-bold">
-            type <span className="text-ludo-danger">{destructiveConfirmation.confirmationValue}</span>  to confirm
+            type
+            <span className="text-ludo-danger">
+              {destructiveConfirmation.confirmationValue}
+            </span>
+            to confirm
           </DialogDescription>
-          <Input className="text-ludoAltText" onChange={(e) => setConfirmationValue(e.target.value)}/>
+          <Input
+            className="text-ludoAltText"
+            onChange={(e) => setConfirmationValue(e.target.value)}
+          />
         </>
       )}
 

--- a/packages/types/User/TogglePreferencesRequest.ts
+++ b/packages/types/User/TogglePreferencesRequest.ts
@@ -1,0 +1,4 @@
+export type TogglePreferencesRequest = {
+  aiEnabled: boolean;
+  audioEnabled: boolean;
+};

--- a/packages/types/User/UserPreferences.ts
+++ b/packages/types/User/UserPreferences.ts
@@ -4,5 +4,7 @@ import type { OnboardingCareerType } from "../Onboarding/OnboardingCourse"
 export type UserPreferences = {
     userId: UUID,
     hasExperience: boolean,
-    chosenPath: OnboardingCareerType
+    chosenPath: OnboardingCareerType,
+    aiEnabled: boolean,
+    audioEnabled: boolean
 }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -57,6 +57,7 @@ export * from "./User/UserPreferences";
 export * from "./User/UserStreak";
 export * from "./User/AvatarInfo";
 export * from "./User/EditProfileRequest";
+export * from "./User/TogglePreferencesRequest"
 
 // Zod
 export * from "./Zod/OnboardingSchema/OnboardingSnapSchema";


### PR DESCRIPTION
## Changes

- Added `useEditProfile` hook & mutation
- OnSuccess sets `qo.preferences()` queryData to server response
- After mutation finished, navigates back to profile page with saved preferences