### PR TITLE
fix(delete account): Navigate without error to auth page

### DIFF
--- a/apps/web/src/features/Onboarding/Hook/useOnboardingDraft.tsx
+++ b/apps/web/src/features/Onboarding/Hook/useOnboardingDraft.tsx
@@ -19,6 +19,7 @@ export function useOnboardingDraft(): UseOnboardingDraftReturn {
   const queryClient = useQueryClient();
 
   const { data: draft = {} } = useQuery<OnboardingDraft>({
+    queryFn: async () => ({}),
     queryKey: qk.onboardingDraft(),
     initialData: {},
     staleTime: Infinity,
@@ -30,7 +31,7 @@ export function useOnboardingDraft(): UseOnboardingDraftReturn {
       (draft = {}) => ({
         ...draft,
         ...patch,
-      })
+      }),
     );
 
   const clearDraft = () =>

--- a/apps/web/src/hooks/Queries/Mutations/useDeleteAccount.tsx
+++ b/apps/web/src/hooks/Queries/Mutations/useDeleteAccount.tsx
@@ -7,15 +7,11 @@ export function useDeleteAccount() {
   const router = useRouter();
   const qc = useQueryClient();
 
-  const logoutMutation = useMutation(mutations.logOut());
-
   return useMutation({
     ...mutations.deleteAccount(),
     onSuccess: async () => {
-      await logoutMutation.mutateAsync();
-
+      await router.navigate(ludoNavigation.auth.login());
       qc.clear();
-      router.navigate(ludoNavigation.auth.login());
     },
   });
 }

--- a/apps/web/src/routes/_app/onboarding.$stage.tsx
+++ b/apps/web/src/routes/_app/onboarding.$stage.tsx
@@ -14,9 +14,12 @@ export const Route = createFileRoute("/_app/onboarding/$stage")({
   }),
 
   beforeLoad: ({ params, context }) => {
+    console.log("CHILD beforeLoad");
     const draft =
       context.queryClient.getQueryData<OnboardingDraft>(qk.onboardingDraft()) ??
       {};
+
+    console.log(JSON.stringify(draft));
 
     const invalid = firstInvalidStep(draft);
     if (!invalid) return;
@@ -25,6 +28,13 @@ export const Route = createFileRoute("/_app/onboarding/$stage")({
     const invalidIdx = stepOrder.indexOf(invalid);
 
     if (currentIdx > invalidIdx) {
+      console.log(
+        "INVALID INDEX: " +
+          "CURRENT: " +
+          currentIdx +
+          " INVALID: " +
+          invalidIdx,
+      );
       throw redirect({
         to: "/onboarding/$stage",
         params: { stage: invalid },

--- a/packages/design-system/templates/dialog/WarningDialog.tsx
+++ b/packages/design-system/templates/dialog/WarningDialog.tsx
@@ -50,7 +50,8 @@ export function WarningDialog({
           <DialogDescription className="text-white code font-bold">
             type
             <span className="text-ludo-danger">
-              {destructiveConfirmation.confirmationValue}
+              {" "}
+              {destructiveConfirmation.confirmationValue}{" "}
             </span>
             to confirm
           </DialogDescription>


### PR DESCRIPTION
## Changes

- Delete mutation now no longer calls logout mutateAsync, instead it navigates to auth page and then clears query caches.

## Related Issues
- Closes: #199 