### PR TITLE
feat(completions): Add badge earned animation to completion page

### DIFF
--- a/apps/web/src/features/Completion/Components/Zone/CompletionFooter.tsx
+++ b/apps/web/src/features/Completion/Components/Zone/CompletionFooter.tsx
@@ -20,20 +20,20 @@ export function CompletionFooter() {
             ludoNavigation.completion.toStreakIncrease(
               courseId,
               moduleId,
-              lessonId
-            )
+              lessonId,
+            ),
           );
         } else if (isCourseCompleteForFirstTime) {
           router.navigate(
             ludoNavigation.completion.toCourseComplete(
               courseId,
               moduleId,
-              lessonId
-            )
+              lessonId,
+            ),
           );
         } else {
           router.navigate(
-            ludoNavigation.hub.module.toModule(courseId, moduleId, true)
+            ludoNavigation.hub.module.toModule(courseId, moduleId, true),
           );
         }
         break;
@@ -44,18 +44,20 @@ export function CompletionFooter() {
             ludoNavigation.completion.toCourseComplete(
               courseId,
               moduleId,
-              lessonId
-            )
+              lessonId,
+            ),
           );
         } else {
           router.navigate(
-            ludoNavigation.hub.module.toModule(courseId, moduleId, true)
+            ludoNavigation.hub.module.toModule(courseId, moduleId, true),
           );
         }
         break;
 
       case "course":
-        router.navigate(ludoNavigation.hub.module.toModule(courseId, moduleId, true));
+        router.navigate(
+          ludoNavigation.hub.module.toModule(courseId, moduleId, true),
+        );
         break;
     }
   };

--- a/apps/web/src/features/Completion/Pages/CompletionPage.tsx
+++ b/apps/web/src/features/Completion/Pages/CompletionPage.tsx
@@ -1,10 +1,11 @@
-import confettiAnimationData from "../../../../public/Animations/LC_CONFETTI_SLOW.json";
 import streakAnimationData from "../../../../public/Animations/STR_INCREASE.json";
 import Lottie from "lottie-react";
 import { useCompletionContext } from "@/features/Completion/Context/CompletionContext.tsx";
 import { CompletionStatsGroup } from "@/features/Completion/Components/Stats/CompletionStatsGroup.tsx";
 import { IncrementingCounter } from "@ludocode/design-system/primitives/incrementing-counter";
 import { useLottie, useTimedLottie } from "@ludocode/hooks";
+import { BadgeSingleCard } from "@/features/Hub/ProfileHub/Components/Card/BadgeCard";
+import type { IconName } from "@ludocode/design-system/primitives/custom-icon";
 
 export function LessonCompletionPage() {
   const { search } = useCompletionContext();
@@ -48,23 +49,19 @@ export function StreakIncreasePage() {
 }
 
 export function CourseCompletePage() {
-  const { lottieRef } = useTimedLottie({ minusFrames: 1 });
   const { courseName } = useCompletionContext();
 
   return (
     <>
-      <Lottie
-        lottieRef={lottieRef}
-        animationData={confettiAnimationData}
-        autoPlay={false}
-        loop={true}
-        className="w-full h-100 border-t border-b mb-4"
-      />
       <div className="flex text-center gap-8 flex-col">
         <h2 className="text-3xl">Course Complete!</h2>
         <p className="text-lg">
           Congratulations on completing the {courseName} course!
         </p>
+        <p>You've earned the {courseName} badge!</p>
+        <div className="w-full flex items-center justify-center">
+          <BadgeSingleCard clickable={false} icon={courseName as IconName} />
+        </div>
       </div>
     </>
   );

--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/BadgeCard.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/BadgeCard.tsx
@@ -1,14 +1,24 @@
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
-import { Badge } from "@ludocode/design-system/primitives/badge";
+import {
+  AnimatedBadge,
+  Badge,
+  type BadgeProps,
+} from "@ludocode/design-system/primitives/badge";
 import type { CourseStats, LudoCourse } from "@ludocode/types";
 import type { IconName } from "@ludocode/design-system/primitives/custom-icon";
+import { cn } from "@ludocode/design-system/cn-utils";
 
-type BadgeCardProps = {
+type BadgeCardListProps = {
   allCourses: LudoCourse[];
   allCourseStats: CourseStats[];
+  clickable?: boolean;
 };
 
-export function BadgeCard({ allCourses, allCourseStats }: BadgeCardProps) {
+export function BadgeListCard({
+  allCourses,
+  allCourseStats,
+  clickable = true
+}: BadgeCardListProps) {
   const completedCourseIds = new Set(
     allCourseStats
       .filter((stat) => stat.completedLessons === stat.totalLessons)
@@ -20,12 +30,26 @@ export function BadgeCard({ allCourses, allCourseStats }: BadgeCardProps) {
   );
 
   return (
-    <div className="w-full flex">
-      <LudoButton className="flex items-center justify-start px-4 py-4 h-auto gap-2">
+    <div className={cn("flex w-full")}>
+      <LudoButton clickable={clickable} className="flex items-center justify-start px-4 py-4 h-auto gap-2">
         {completedCourses.map((course) => (
           <Badge icon={course.title as IconName} />
         ))}
       </LudoButton>
     </div>
+  );
+}
+
+type BadgeSingleCardProps = {
+  animated?: boolean;
+  icon: IconName;
+  clickable?: boolean;
+};
+
+export function BadgeSingleCard({ icon, animated, clickable }: BadgeSingleCardProps) {
+  return (
+    <LudoButton clickable={clickable} className="flex w-auto items-center justify-start px-4 py-4 h-auto gap-2">
+      {animated ? <Badge icon={icon} /> : <AnimatedBadge icon={icon} />}
+    </LudoButton>
   );
 }

--- a/apps/web/src/features/Hub/ProfileHub/Pages/ProfilePage.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Pages/ProfilePage.tsx
@@ -5,7 +5,7 @@ import { AccountActionsGroup } from "../Components/Group/AccountActionsGroup";
 import { ProfileCardContainer } from "../Components/Card/ProfileCardContainer";
 import { UserStatsGroup } from "../Components/Group/UserStatsGroup";
 import { CurrentCourseCard } from "../Components/Card/CurrentCourseCard";
-import { BadgeCard } from "../Components/Card/BadgeCard";
+import { BadgeListCard } from "../Components/Card/BadgeCard";
 
 type ProfilePageProps = {};
 
@@ -43,7 +43,10 @@ export function ProfilePage({}: ProfilePageProps) {
           />
         </ProfileCardContainer>
         <ProfileCardContainer header="BADGES">
-          <BadgeCard allCourses={allCourses} allCourseStats={allCourseStats} />
+          <BadgeListCard
+            allCourses={allCourses}
+            allCourseStats={allCourseStats}
+          />
         </ProfileCardContainer>
       </div>
     </div>

--- a/packages/design-system/primitives/badge.tsx
+++ b/packages/design-system/primitives/badge.tsx
@@ -2,13 +2,33 @@ import {
   CustomIcon,
   type IconName,
 } from "@ludocode/design-system/primitives/custom-icon";
+import { motion } from "framer-motion";
 
-type BadgeProps = { icon: IconName };
+export type BadgeProps = { icon: IconName };
 
 export function Badge({ icon }: BadgeProps) {
   return (
     <div className="h-10 w-10 bg-ludo-background rounded-md flex items-center justify-center">
       <CustomIcon className="h-5 w-5" color="white" iconName={icon} />
+    </div>
+  );
+}
+
+export function AnimatedBadge({ icon }: BadgeProps) {
+  return (
+    <div className="h-10 w-10 bg-ludo-background rounded-md flex items-center justify-center">
+      <motion.div
+        key={icon}
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{
+          duration: 2,
+          ease: "easeOut",
+          scale: { type: "spring", stiffness: 200, damping: 15 },
+        }}
+      >
+        <CustomIcon className="h-5 w-5" color="white" iconName={icon} />
+      </motion.div>
     </div>
   );
 }

--- a/packages/design-system/primitives/ludo-button.tsx
+++ b/packages/design-system/primitives/ludo-button.tsx
@@ -7,6 +7,7 @@ type Variant = "default" | "alt" | "white" | "danger";
 type LudoButtonProps = React.ComponentPropsWithoutRef<"button"> & {
   selected?: boolean;
   shadow?: boolean;
+  clickable?: boolean;
   isLoading?: boolean;
   variant?: Variant;
   disabled?: boolean;
@@ -18,6 +19,7 @@ export const LudoButton = forwardRef<HTMLButtonElement, LudoButtonProps>(
     {
       children,
       className,
+      clickable = true,
       shadow = true,
       isLoading = false,
       selected = false,
@@ -56,15 +58,21 @@ export const LudoButton = forwardRef<HTMLButtonElement, LudoButtonProps>(
       danger: "shadow-[0_5px_0_#C85A5A]/50",
     };
 
+    const clickableStyles = clickable ? "hover:cursor-pointer" : "";
+    const clickableShadowStyle =
+      clickable && shadow ? "active:translate-y-1 active:shadow-none" : "";
+
     return (
       <button
         ref={ref}
         type="button"
         className={cn(
-          "h-10 w-full rounded-lg flex justify-center items-center gap-3 hover:cursor-pointer",
+          "h-10 w-full rounded-lg flex justify-center items-center gap-3",
+          clickableStyles,
           shadow
-            ? `${disabled || isLoading ? disabledShadowStyles[variant] : shadowMap[variant]} active:translate-y-1 active:shadow-none`
+            ? `${disabled || isLoading ? disabledShadowStyles[variant] : shadowMap[variant]}`
             : "",
+          clickableShadowStyle,
           `${disabled || isLoading ? disabledVariantStyles[variant] : variantStyles[variant]}`,
           className,
         )}


### PR DESCRIPTION
## Changes

- Removed confetti lottie animation from course complete page
- Added a badge earned fade in animation that shows the completed course

## Related Issues
- Closes: #209 

## Screenshots
<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/f8a635c0-5926-4598-a41b-b309feb4bc68" />
