### PR TITLE
refactor(plan overview): Switch to simplified backend response

### DIFF
--- a/apps/web/src/features/Subscription/Comparison/Components/SubscriptionOverviewCard.tsx
+++ b/apps/web/src/features/Subscription/Comparison/Components/SubscriptionOverviewCard.tsx
@@ -3,7 +3,7 @@ import { planStyles, type PlanStyleConfig } from "../content";
 import { LudoCard } from "@ludocode/design-system/primitives/ludo-card";
 import { FeatureRow } from "./FeatureRow";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
-import type { PlanOverview } from "@ludocode/types";
+import type { Feature, PlanOverview } from "@ludocode/types";
 
 type SubscriptionOverviewCardProps = { plan: PlanOverview };
 
@@ -11,6 +11,15 @@ export function SubscriptionOverviewCard({
   plan,
 }: SubscriptionOverviewCardProps) {
   const styles = planStyles[plan.tier];
+
+  const ALL_FEATURES: { code: Feature; title: string }[] = [
+    { code: "CORE_COURSES", title: "Core Courses" },
+    { code: "CODE_EDITOR", title: "Built-in Code Editor" },
+    { code: "PUBLISH_PROJECTS", title: "Publish Projects" },
+    { code: "SKILL_PATHS", title: "Skill Paths" },
+    { code: "AI_ASSISTANT", title: "AI Assistant" },
+    { code: "PRIORITY_SUPPORT", title: "Priority Support" },
+  ];
 
   return (
     <LudoCard
@@ -35,9 +44,17 @@ export function SubscriptionOverviewCard({
       <div className="h-px bg-ludo-border" />
 
       <div className="flex flex-col flex-1">
-        {plan.features.map((f) => (
-          <FeatureRow key={f.title} included={f.enabled} label={f.title} />
-        ))}
+        {ALL_FEATURES.map((feature) => {
+          const included = plan.features.includes(feature.code);
+
+          return (
+            <FeatureRow
+              key={feature.code}
+              included={included}
+              label={feature.title}
+            />
+          );
+        })}
       </div>
 
       <div className="h-px bg-ludo-border" />
@@ -94,14 +111,18 @@ function SubscriptionLimitsOverview({
         Limits
       </span>
       <div className="flex flex-col gap-1.5">
-        {limits.map((limit) => (
-          <div key={limit.title} className="flex items-center justify-between">
-            <span className="text-xs text-ludo-text-dim">{limit.title}</span>
-            <span className="text-xs font-medium text-ludoAltText">
-              {limit.limit}
-            </span>
-          </div>
-        ))}
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-ludo-text-dim">Max Projects</span>
+          <span className="text-xs font-medium text-ludoAltText">
+            {limits.maxProjects}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-ludo-text-dim">Monthly AI credits</span>
+          <span className="text-xs font-medium text-ludoAltText">
+            {limits.monthlyAiCredits}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/Subscription/Comparison/content.ts
+++ b/apps/web/src/features/Subscription/Comparison/content.ts
@@ -9,10 +9,12 @@ export type PlanStyleConfig = {
   buttonVariant: "default" | "alt";
   glow: string;
   recommended?: boolean;
+  title: string;
 };
 
 export const planStyles: Record<SubscriptionPlan, PlanStyleConfig> = {
   FREE: {
+    title: "Access to core courses",
     featureKey: "free",
     badge: "FREE",
     badgeBg: "bg-ludo-surface",
@@ -23,6 +25,7 @@ export const planStyles: Record<SubscriptionPlan, PlanStyleConfig> = {
   },
 
   CORE: {
+    title: "Unlock the full learning experience",
     featureKey: "core",
     badge: "CORE",
     badgeBg: "bg-gradient-to-r from-ludo-accent to-ludo-progress",
@@ -34,6 +37,7 @@ export const planStyles: Record<SubscriptionPlan, PlanStyleConfig> = {
   },
 
   PRO: {
+    title: "Everything, plus AI and priority perks",
     featureKey: "pro",
     badge: "PRO",
     badgeBg: "bg-gradient-to-r from-purple-500 to-fuchsia-400",

--- a/packages/types/Subscription/PlanOverview.ts
+++ b/packages/types/Subscription/PlanOverview.ts
@@ -1,21 +1,23 @@
 import { SubscriptionPlan } from "./SubscriptionPlan"
 
-export type PlanFeaturesOverview = {
-  title: string
-  enabled: boolean
-}
+export type Feature =
+  | "CORE_COURSES"
+  | "CODE_EDITOR"
+  | "PUBLISH_PROJECTS"
+  | "SKILL_PATHS"
+  | "AI_ASSISTANT"
+  | "PRIORITY_SUPPORT";
 
-export type PlanLimitsOverview = {
-  title: string
-  limit: number
-}
-
+export type PlanLimits = {
+  monthlyAiCredits: number;
+  maxProjects: number;
+};
 export type PlanOverview = {
-  tier: SubscriptionPlan
-  price: number
-  period: string
-  description: string
-  recommended: boolean
-  features: PlanFeaturesOverview[]
-  limits: PlanLimitsOverview[]
-}
+  tier: SubscriptionPlan;
+  price: number;
+  period: string;
+  description: string;
+  recommended: boolean;
+  features: Feature[];
+  limits: PlanLimits;
+};


### PR DESCRIPTION
## Changes

- Switched to simplified backend config
- UI text such as plan feature name are left to the frontend
- Backend now only says whether a feature is enabled (i.e. is in features array of the response), and the limit of a specific feature

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements
- Added descriptive titles to subscription plans for clearer differentiation
- Standardized subscription feature display with consistent, predictable ordering
- Enhanced subscription limits visibility by explicitly showing Max Projects and Monthly AI Credits metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->