### PR TITLE
feat(subscriptions): Add manage plan hook & style error components

### DIFF
--- a/apps/web/src/constants/content/ErrorData.ts
+++ b/apps/web/src/constants/content/ErrorData.ts
@@ -1,30 +1,58 @@
 import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
-import type { NavigateOptions } from "@tanstack/react-router";
+import type { LudoButtonVariant } from "@ludocode/design-system/primitives/ludo-button";
+
+import { RefreshCcwIcon } from "lucide-react";
+
+type ErrorAction = {
+  text: string;
+  variant?: LudoButtonVariant;
+  icon?: React.ComponentType<{ className?: string }>;
+  handler: (router: ReturnType<typeof import("@tanstack/react-router").useRouter>) => void;
+};
+
 type ErrorEntry = {
   status: ErrorStatus;
   title: string;
   suggestion: string;
-  actionText: string;
-  fallbackAction?: () => NavigateOptions;
+  actions?: ErrorAction[];
 };
-
 export type ErrorStatus = 404 | 500;
 
 type ErrorMap = Record<ErrorStatus, ErrorEntry>;
+
 
 export const errorMap: ErrorMap = {
   404: {
     status: 404,
     title: "The page you are looking for couldn't be found",
     suggestion: "Did you make sure the url is correct?",
-    actionText: "Go to home",
-    fallbackAction: () => ludoNavigation.courseRoot(),
+    actions: [
+      {
+        text: "Go to home",
+        variant: "white",
+        handler: (router) =>
+          router.navigate(ludoNavigation.courseRoot()),
+      },
+    ],
   },
   500: {
     status: 500,
     title: "Encountered unexpected error on our side, sorry!",
     suggestion:
       "Try refreshing the page or inspecting the error in the developer tools",
-    actionText: "Go to home",
+    actions: [
+      {
+        text: "Refresh",
+        variant: "alt",
+        icon: RefreshCcwIcon,
+        handler: () => window.location.reload(),
+      },
+      {
+        text: "Go to home",
+        variant: "white",
+        handler: (router) =>
+          router.navigate(ludoNavigation.courseRoot()),
+      },
+    ],
   },
 };

--- a/apps/web/src/features/Error/ErrorPage.tsx
+++ b/apps/web/src/features/Error/ErrorPage.tsx
@@ -8,8 +8,7 @@ type ErrorPageProps = { errorCode: ErrorStatus };
 
 export function ErrorPage({ errorCode }: ErrorPageProps) {
   const router = useRouter();
-  const { status, title, suggestion, actionText, fallbackAction } =
-    errorMap[errorCode];
+  const { status, title, suggestion, actions } = errorMap[errorCode];
 
   return (
     <FallbackLayout>
@@ -32,18 +31,22 @@ export function ErrorPage({ errorCode }: ErrorPageProps) {
             </p>
           </div>
 
-          {fallbackAction && (
+          {actions && (
             <div className="flex gap-4">
-              <LudoButton
-                className="w-auto px-4"
-                variant="white"
-                onClick={() => {
-                  const nav = fallbackAction();
-                  if (nav) router.navigate(nav);
-                }}
-              >
-                {actionText}
-              </LudoButton>
+              {actions.map((action, i) => {
+                const Icon = action.icon;
+                return (
+                  <LudoButton
+                    key={i}
+                    className="w-auto px-4 flex items-center gap-2"
+                    variant={action.variant ?? "white"}
+                    onClick={() => action.handler(router)}
+                  >
+                    {Icon && <Icon className="size-4" />}
+                    {action.text}
+                  </LudoButton>
+                );
+              })}
             </div>
           )}
         </div>

--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/AICreditBalanceCard.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/AICreditBalanceCard.tsx
@@ -1,19 +1,24 @@
 import { ludoNavigation } from "@/constants/ludoNavigation";
+import { useStripeManage } from "@/hooks/Queries/Mutations/useStripeManage";
 import { router } from "@/main";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
 import { LudoCard } from "@ludocode/design-system/primitives/ludo-card";
+import type { SubscriptionPlan } from "@ludocode/types";
 import React from "react";
+import { SubscriptionActionButton } from "./SubscriptionActionButton";
 
 type AICreditBalanceCardProps = {
   remaining: number;
   allowance: number;
   renewalDate: string;
+  planCode: SubscriptionPlan;
 };
 
 export function AICreditBalanceCard({
   remaining,
   allowance,
   renewalDate,
+  planCode,
 }: AICreditBalanceCardProps) {
   const fields: Array<{ label: string; value: React.ReactNode }> = [
     { label: "Credits remaining:", value: remaining },
@@ -22,7 +27,10 @@ export function AICreditBalanceCard({
   ];
 
   return (
-    <LudoCard shadow={false} className="grid h-auto p-4 text-sm lg:text-md grid-cols-[2fr_1fr] grid-rows-4">
+    <LudoCard
+      shadow={false}
+      className="grid h-auto p-4 text-sm lg:text-md grid-cols-[2fr_1fr] grid-rows-4"
+    >
       {fields.map((f) => (
         <React.Fragment key={f.label}>
           <p className="text-left">{f.label}</p>
@@ -32,9 +40,7 @@ export function AICreditBalanceCard({
 
       <div className="col-span-2 flex justify-between items-center">
         <p className="text-left">Need more?</p>
-        <LudoButton onClick={() => router.navigate(ludoNavigation.subscription.toSubscriptionComparisonPage())} className="w-1/2 h-auto py-1" variant="alt">
-          Upgrade Plan
-        </LudoButton>
+        <SubscriptionActionButton plan={planCode}/>
       </div>
     </LudoCard>
   );

--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/SubscriptionActionButton.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/SubscriptionActionButton.tsx
@@ -1,0 +1,34 @@
+import { ludoNavigation } from "@/constants/ludoNavigation";
+import { useStripeManage } from "@/hooks/Queries/Mutations/useStripeManage";
+import { router } from "@/main";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import type { SubscriptionPlan } from "@ludocode/types";
+
+type SubscriptionActionButtonProps = { plan: SubscriptionPlan };
+
+export function SubscriptionActionButton({
+  plan,
+}: SubscriptionActionButtonProps) {
+  const text = plan == "PATRON" ? "Manage plan" : "Upgrade plan";
+  const { openManagePortal } = useStripeManage();
+
+  const onClick = () => {
+    if (plan == "PATRON") {
+      openManagePortal();
+    } else {
+      router.navigate(
+        ludoNavigation.subscription.toSubscriptionComparisonPage(),
+      );
+    }
+  };
+
+  return (
+    <LudoButton
+      onClick={() => onClick()}
+      className="w-1/2 h-auto py-1"
+      variant="alt"
+    >
+      {text}
+    </LudoButton>
+  );
+}

--- a/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
@@ -24,7 +24,7 @@ export function AccountSettingsPage() {
   const userPfpSrc = getUserAvatar(avatarVersion, avatarIndex);
 
   const { data: subscription } = useSuspenseQuery(qo.subscription());
-  const { monthlyCreditAllowance, currentPeriodEnd } = subscription;
+  const { monthlyCreditAllowance, currentPeriodEnd, planCode } = subscription;
   const renewalDate = parseToDigitDate(Number(currentPeriodEnd));
   const { data: aiCredits } = useSuspenseQuery(qo.credits());
 
@@ -77,6 +77,7 @@ export function AccountSettingsPage() {
 
         <ProfileCardContainer header="AI">
           <AICreditBalanceCard
+            planCode={planCode}
             remaining={aiCredits}
             allowance={monthlyCreditAllowance}
             renewalDate={renewalDate}

--- a/apps/web/src/features/Onboarding/Hook/__tests__/fixtures.ts
+++ b/apps/web/src/features/Onboarding/Hook/__tests__/fixtures.ts
@@ -26,7 +26,8 @@ export const testUser: LoginUserResponse = {
     planId: "plan_patron",
     monthlyCreditAllowance: 10,
     maxProjects: 3,
-    currentPeriodEnd: "next month"
+    currentPeriodEnd: "next month",
+    cancelAtPeriodEnd: false
   }
 };
 

--- a/apps/web/src/features/Project/FileTree/ProjectFileTree.tsx
+++ b/apps/web/src/features/Project/FileTree/ProjectFileTree.tsx
@@ -15,7 +15,7 @@ export function ProjectFileTree() {
   );
 
   return (
-    <div className="flex px-4 py-3 overflow-y-auto min-h-0 h-full bg-ludo-background gap-2 text-white flex-col w-full">
+    <div className="flex px-4 py-3 overflow-y-auto overflow-x-hidden min-h-0 h-full bg-ludo-background gap-2 text-white flex-col w-full">
       {files.map((file, index) => {
         const key = file.id ?? file.tempId!;
         return (

--- a/apps/web/src/features/Project/ProjectPage.tsx
+++ b/apps/web/src/features/Project/ProjectPage.tsx
@@ -22,11 +22,11 @@ export function ProjectPage() {
 
   return (
     <div className="grid col-span-full min-h-0 grid-cols-12">
-      <div className="col-span-1 min-h-0 bg-ludo-background border-r-2 grid grid-rows-[auto_1fr_auto] border-r-ludo-surface lg:col-span-3">
+      <div className="col-span-1 min-w-0 w-full min-h-0 bg-ludo-background border-r-2 grid grid-rows-[auto_1fr_auto] border-r-ludo-surface lg:col-span-3">
         <FileTreeWinbar />
         <ProjectFileTree />
         {aiEnabled && (
-          <div className="min-h-0 w-full h-full flex flex-col justify-end">
+          <div className="min-h-0 min-w-0 w-full h-full flex flex-col justify-end">
             <ChatBotProvider
               credits={chatbotCredits}
               targetId={project.projectId}

--- a/apps/web/src/hooks/Queries/Mutations/useStripeManage.tsx
+++ b/apps/web/src/hooks/Queries/Mutations/useStripeManage.tsx
@@ -1,0 +1,20 @@
+import { api } from "@/constants/api/api";
+
+export function useStripeManage() {
+  async function openManagePortal() {
+    const res = await fetch(api.subscriptions.manage, {
+      method: "POST",
+      credentials: "include",
+    });
+
+    if (!res.ok) {
+      throw new Error("Failed to create billing portal session");
+    }
+
+    const { url } = await res.json();
+
+    window.location.href = url;
+  }
+
+  return { openManagePortal };
+}

--- a/apps/web/src/layouts/Fallback/FallbackLayout.tsx
+++ b/apps/web/src/layouts/Fallback/FallbackLayout.tsx
@@ -5,8 +5,8 @@ type FallbackLayoutProps = { children: ReactNode };
 
 export function FallbackLayout({ children }: FallbackLayoutProps) {
   return (
-    <MainGridWrapper gridRows={"ONE"}>
+    <div className="h-dvh w-dvw bg-ludo-background fixed">
       {children}
-    </MainGridWrapper>
+    </div>
   );
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as AppHubRouteRouteImport } from './routes/_app/_hub/route'
 import { Route as AppDesktopguardRouteRouteImport } from './routes/_app/_desktopguard/route'
 import { Route as AppSyncLessonIdRouteImport } from './routes/_app/sync/$lessonId'
 import { Route as AppSubscriptionSuccessRouteImport } from './routes/_app/subscription/success'
+import { Route as AppSubscriptionManageRouteImport } from './routes/_app/subscription/manage'
 import { Route as AppSubscriptionConfirmRouteImport } from './routes/_app/subscription/confirm'
 import { Route as AppSubscriptionComparisonRouteImport } from './routes/_app/subscription/comparison'
 import { Route as AppSubscriptionCancelRouteImport } from './routes/_app/subscription/cancel'
@@ -79,6 +80,11 @@ const AppSyncLessonIdRoute = AppSyncLessonIdRouteImport.update({
 const AppSubscriptionSuccessRoute = AppSubscriptionSuccessRouteImport.update({
   id: '/success',
   path: '/success',
+  getParentRoute: () => AppSubscriptionRouteRoute,
+} as any)
+const AppSubscriptionManageRoute = AppSubscriptionManageRouteImport.update({
+  id: '/manage',
+  path: '/manage',
   getParentRoute: () => AppSubscriptionRouteRoute,
 } as any)
 const AppSubscriptionConfirmRoute = AppSubscriptionConfirmRouteImport.update({
@@ -172,6 +178,7 @@ export interface FileRoutesByFullPath {
   '/subscription/cancel': typeof AppSubscriptionCancelRoute
   '/subscription/comparison': typeof AppSubscriptionComparisonRoute
   '/subscription/confirm': typeof AppSubscriptionConfirmRoute
+  '/subscription/manage': typeof AppSubscriptionManageRoute
   '/subscription/success': typeof AppSubscriptionSuccessRoute
   '/sync/$lessonId': typeof AppSyncLessonIdRoute
   '/project/$projectId': typeof AppDesktopguardProjectProjectIdRoute
@@ -195,6 +202,7 @@ export interface FileRoutesByTo {
   '/subscription/cancel': typeof AppSubscriptionCancelRoute
   '/subscription/comparison': typeof AppSubscriptionComparisonRoute
   '/subscription/confirm': typeof AppSubscriptionConfirmRoute
+  '/subscription/manage': typeof AppSubscriptionManageRoute
   '/subscription/success': typeof AppSubscriptionSuccessRoute
   '/sync/$lessonId': typeof AppSyncLessonIdRoute
   '/project/$projectId': typeof AppDesktopguardProjectProjectIdRoute
@@ -220,6 +228,7 @@ export interface FileRoutesById {
   '/_app/subscription/cancel': typeof AppSubscriptionCancelRoute
   '/_app/subscription/comparison': typeof AppSubscriptionComparisonRoute
   '/_app/subscription/confirm': typeof AppSubscriptionConfirmRoute
+  '/_app/subscription/manage': typeof AppSubscriptionManageRoute
   '/_app/subscription/success': typeof AppSubscriptionSuccessRoute
   '/_app/sync/$lessonId': typeof AppSyncLessonIdRoute
   '/_app/_desktopguard/project/$projectId': typeof AppDesktopguardProjectProjectIdRoute
@@ -245,6 +254,7 @@ export interface FileRouteTypes {
     | '/subscription/cancel'
     | '/subscription/comparison'
     | '/subscription/confirm'
+    | '/subscription/manage'
     | '/subscription/success'
     | '/sync/$lessonId'
     | '/project/$projectId'
@@ -268,6 +278,7 @@ export interface FileRouteTypes {
     | '/subscription/cancel'
     | '/subscription/comparison'
     | '/subscription/confirm'
+    | '/subscription/manage'
     | '/subscription/success'
     | '/sync/$lessonId'
     | '/project/$projectId'
@@ -292,6 +303,7 @@ export interface FileRouteTypes {
     | '/_app/subscription/cancel'
     | '/_app/subscription/comparison'
     | '/_app/subscription/confirm'
+    | '/_app/subscription/manage'
     | '/_app/subscription/success'
     | '/_app/sync/$lessonId'
     | '/_app/_desktopguard/project/$projectId'
@@ -381,6 +393,13 @@ declare module '@tanstack/react-router' {
       path: '/success'
       fullPath: '/subscription/success'
       preLoaderRoute: typeof AppSubscriptionSuccessRouteImport
+      parentRoute: typeof AppSubscriptionRouteRoute
+    }
+    '/_app/subscription/manage': {
+      id: '/_app/subscription/manage'
+      path: '/manage'
+      fullPath: '/subscription/manage'
+      preLoaderRoute: typeof AppSubscriptionManageRouteImport
       parentRoute: typeof AppSubscriptionRouteRoute
     }
     '/_app/subscription/confirm': {
@@ -530,6 +549,7 @@ interface AppSubscriptionRouteRouteChildren {
   AppSubscriptionCancelRoute: typeof AppSubscriptionCancelRoute
   AppSubscriptionComparisonRoute: typeof AppSubscriptionComparisonRoute
   AppSubscriptionConfirmRoute: typeof AppSubscriptionConfirmRoute
+  AppSubscriptionManageRoute: typeof AppSubscriptionManageRoute
   AppSubscriptionSuccessRoute: typeof AppSubscriptionSuccessRoute
 }
 
@@ -537,6 +557,7 @@ const AppSubscriptionRouteRouteChildren: AppSubscriptionRouteRouteChildren = {
   AppSubscriptionCancelRoute: AppSubscriptionCancelRoute,
   AppSubscriptionComparisonRoute: AppSubscriptionComparisonRoute,
   AppSubscriptionConfirmRoute: AppSubscriptionConfirmRoute,
+  AppSubscriptionManageRoute: AppSubscriptionManageRoute,
   AppSubscriptionSuccessRoute: AppSubscriptionSuccessRoute,
 }
 

--- a/apps/web/src/routes/_app/subscription/manage.tsx
+++ b/apps/web/src/routes/_app/subscription/manage.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_app/subscription/manage')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/_app/subscription/manage"!</div>
+}

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -120,6 +120,7 @@ export function createApiPaths({
       base: `${BASE}/subscription`,
       checkout: `${BASE}/subscription/checkout`,
       confirm: `${BASE}/subscription/confirm`,
+      manage: `${BASE}/subscription/manage`,
       plans: `${BASE}/subscription/plans`
     },
 

--- a/packages/design-system/styles/theme/chatbot.css
+++ b/packages/design-system/styles/theme/chatbot.css
@@ -40,6 +40,7 @@
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
+  --border: #22273e;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -53,7 +54,6 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
@@ -67,24 +67,20 @@
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 }
 
 .chatbot-content pre {
-  background: #1c1c2e !important;
-  color: #f8f8f2 !important;
   padding: 12px;
-  border-radius: 8px;
+  border: #22273e !important;
+  border-radius: 0px !important;
   white-space: pre-wrap !important;
   word-break: break-word !important;
-  border: 1px solid #303966;
 }
 
 .chatbot-content code {
   background: #2a2a3d !important;
-  color: #ffea8a !important;
-  padding: 2px 4px;
-  border-radius: 4px;
+  border: #22273e !important;
+  border-radius: 0px !important;
   font-family: "DMMono", monospace;
 }

--- a/packages/design-system/styles/utilities/ludo.css
+++ b/packages/design-system/styles/utilities/ludo.css
@@ -1,7 +1,7 @@
 @layer utilities {
   .scrollbar-ludo-accent {
     scrollbar-width: thin;
-    scrollbar-color: #8369d6 transparent;
+    scrollbar-color: #5c6fd6 transparent;
   }
 
   .scrollbar-none {

--- a/packages/design-system/widgets/chatbot/ChatbotCreditsTab.tsx
+++ b/packages/design-system/widgets/chatbot/ChatbotCreditsTab.tsx
@@ -12,7 +12,7 @@ export function ChatbotCreditsTab({
   return (
     <div
       className={cn(
-        "w-full py-1.5 px-3 bg-ludo-surface flex gap-2 items-center text-ludo-accent-muted border-b-white border-b",
+        "w-full py-1.5 px-3 text-xs bg-ludo-surface flex gap-2 items-center text-ludo-accent-muted",
         className
       )}
     >

--- a/packages/design-system/widgets/chatbot/ChatbotInput.tsx
+++ b/packages/design-system/widgets/chatbot/ChatbotInput.tsx
@@ -34,21 +34,22 @@ export function ChatBotInput({ handleSubmit }: ChatBotInputProps) {
   return (
     <PromptInput
       onSubmit={clearInputAndSubmit}
-      className="mt-4 px-4"
+      className="mt-4 min-w-0"
       globalDrop
       multiple
     >
       <ChatbotCreditsTab credits={credits} />
-      <PromptInputBody>
+      <PromptInputBody className="min-w-0">
         <PromptInputTextarea
+        
           placeholder="Ask your question here."
           onChange={(e: any) => setInput(e.target.value)}
           value={input}
         />
       </PromptInputBody>
-      <PromptInputFooter>
+      <PromptInputFooter className="py-0">
         <PromptInputTools />
-        <PromptInputSubmit disabled={(!input && !status) || creditsEmpty} />
+        <PromptInputSubmit className="bg-ludo-accent" disabled={(!input && !status) || creditsEmpty} />
       </PromptInputFooter>
     </PromptInput>
   );

--- a/packages/design-system/widgets/chatbot/ChatbotWindow.tsx
+++ b/packages/design-system/widgets/chatbot/ChatbotWindow.tsx
@@ -34,12 +34,12 @@ const ChatBotWindow = ({ targetId, type, className }: ChatBotProps) => {
   return (
     <div
       className={cn(
-        "min-h-0 w-full text-white mx-auto relative h-90 max-h-90",
+        "min-h-0 min-w-0 w-full text-white mx-auto relative h-90 max-h-90",
         className
       )}
     >
-      <div className="flex flex-col h-full">
-        <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto">
+      <div className="flex flex-col min-w-0 h-full">
+        <div ref={scrollRef} className="flex-1 min-h-0 min-w-0 overflow-y-auto">
           <ChatBotConversation messages={messages} />
         </div>
 

--- a/packages/external/ai-elements/code-block.tsx
+++ b/packages/external/ai-elements/code-block.tsx
@@ -102,7 +102,7 @@ export const CodeBlock = ({
     <CodeBlockContext.Provider value={{ code }}>
       <div
         className={cn(
-          "group relative w-full  overflow-hidden rounded-md border bg-background text-foreground",
+          "group relative w-full  overflow-hidden rounded-md bg-background text-foreground",
           className
         )}
         {...props}

--- a/packages/external/ai-elements/message.tsx
+++ b/packages/external/ai-elements/message.tsx
@@ -30,8 +30,8 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[80%] flex-col gap-2",
-      from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
+      "group flex w-full flex-col gap-2",
+      from === "user" ? "is-user max-w-[80%] ml-auto justify-end" : "is-assistant",
       className
     )}
     {...props}
@@ -47,7 +47,7 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit flex-col gap-2 overflow-hidden text-sm",
+      "flex max-w-full flex-col gap-2 text-sm break-words",
       "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:rounded-br-none group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground group-[.is-assistant]:w-full group-[.is-assistant]:rounded-lg group-[.is-assistant]:rounded-bl-none group-[.is-assistant]:bg-ludo-surface/50 group-[.is-assistant]:py-3 px-4",
       className

--- a/packages/external/ai-elements/prompt-input.tsx
+++ b/packages/external/ai-elements/prompt-input.tsx
@@ -754,7 +754,7 @@ export const PromptInput = ({
         onSubmit={handleSubmit}
         {...props}
       >
-        <InputGroup className="overflow-hidden">{children}</InputGroup>
+        <InputGroup className="overflow-hidden border-none">{children}</InputGroup>
       </form>
     </>
   );
@@ -865,7 +865,7 @@ export const PromptInputTextarea = ({
 
   return (
     <InputGroupTextarea
-      className={cn("field-sizing-content max-h-30 min-h-10", className)}
+      className={cn("resize-none min-w-0 w-full h-10 min-h-10 max-h-20 scrollbar-none overflow-x-auto overflow-y-hidden whitespace-nowrap", className)}
       name="message"
       onCompositionEnd={() => setIsComposing(false)}
       onCompositionStart={() => setIsComposing(true)}

--- a/packages/external/ai-elements/queue.tsx
+++ b/packages/external/ai-elements/queue.tsx
@@ -215,7 +215,7 @@ export const QueueSectionTrigger = ({
   <CollapsibleTrigger asChild>
     <button
       className={cn(
-        "group flex w-full items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors hover:bg-muted",
+        "group flex w-full items-center justify-between rounded-md bg-ludo-accent-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors hover:bg-muted",
         className
       )}
       type="button"

--- a/packages/external/ui/input-group.tsx
+++ b/packages/external/ui/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "group/Input-group border-Input dark:bg-Input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
+        "group/Input-group border-Input dark:bg-Input/30 relative flex w-full items-center border shadow-xs transition-[color,box-shadow] outline-none",
         "h-9 min-w-0 has-[>textarea]:h-auto",
 
         // Variants based on alignment.
@@ -151,7 +151,7 @@ function InputGroupTextarea({
     <Textarea
       data-slot="input-group-control"
       className={cn(
-        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        "flex-1 resize-none rounded-none border-none bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
         className
       )}
       {...props}

--- a/packages/types/Subscription/UserSubscription.ts
+++ b/packages/types/Subscription/UserSubscription.ts
@@ -7,4 +7,5 @@ export type UserSubscription = {
   monthlyCreditAllowance: number;
   maxProjects: number;
   currentPeriodEnd: string;
+  cancelAtPeriodEnd: boolean;
 };


### PR DESCRIPTION
## Changes

- Added `useStripeManage()` hook to go to billing management
- Added conditionals to display the right subscribe/manage account text & to call right function depending on current subscription

## Misc changes

- Styled error components to take up the full screen (fixed with dvh and dvw), otherwise they were inheriting the layout of the parent route
- Styled AI chatbot elements

## Keywords 

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added subscription management interface with plan upgrade and management options
  * Enhanced error pages with multi-action support and refresh capability

* **Style**
  * Refined chatbot and messaging UI styling with improved visual consistency
  * Updated border colors and scrollbar colors for better visual hierarchy
  * Adjusted input field styling and layout constraints for improved usability

* **Bug Fixes**
  * Fixed layout issues in sidebar AI chat region to ensure full-width rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->