### PR TITLE
feat(subscriptions): Add subscription overview to account settings page

### DIFF
--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/AICreditBalanceCard.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/AICreditBalanceCard.tsx
@@ -11,14 +11,12 @@ type AICreditBalanceCardProps = {
   remaining: number;
   allowance: number;
   renewalDate: string;
-  planCode: SubscriptionPlan;
 };
 
 export function AICreditBalanceCard({
   remaining,
   allowance,
   renewalDate,
-  planCode,
 }: AICreditBalanceCardProps) {
   const fields: Array<{ label: string; value: React.ReactNode }> = [
     { label: "Credits remaining:", value: remaining },
@@ -29,7 +27,7 @@ export function AICreditBalanceCard({
   return (
     <LudoCard
       shadow={false}
-      className="grid h-auto p-4 text-sm lg:text-md grid-cols-[2fr_1fr] grid-rows-4"
+      className="grid h-auto p-4 text-sm lg:text-md grid-cols-[2fr_1fr] grid-rows-3"
     >
       {fields.map((f) => (
         <React.Fragment key={f.label}>
@@ -37,11 +35,6 @@ export function AICreditBalanceCard({
           <p className="text-right">{f.value}</p>
         </React.Fragment>
       ))}
-
-      <div className="col-span-2 flex justify-between items-center">
-        <p className="text-left">Need more?</p>
-        <SubscriptionActionButton plan={planCode}/>
-      </div>
     </LudoCard>
   );
 }

--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/SubscriptionActionButton.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/SubscriptionActionButton.tsx
@@ -25,7 +25,7 @@ export function SubscriptionActionButton({
   return (
     <LudoButton
       onClick={() => onClick()}
-      className="w-1/2 h-auto py-1"
+      className="w-1/3 h-auto py-1"
       variant="alt"
     >
       {text}

--- a/apps/web/src/features/Hub/ProfileHub/Components/Card/SubscriptionStatusCard.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Components/Card/SubscriptionStatusCard.tsx
@@ -1,0 +1,63 @@
+import { LudoCard } from "@ludocode/design-system/primitives/ludo-card";
+import { SubscriptionActionButton } from "./SubscriptionActionButton";
+import type { SubscriptionPlan } from "@ludocode/types";
+import { parseToDigitDate } from "@ludocode/util/date/dateUtils";
+
+type SubscriptionStatusCardProps = {
+  planCode: SubscriptionPlan;
+  currentPeriodEnd: string;
+  cancelAtPeriodEnd: boolean;
+};
+
+export function SubscriptionStatusCard({
+  planCode,
+  currentPeriodEnd,
+  cancelAtPeriodEnd,
+}: SubscriptionStatusCardProps) {
+  const isFree = planCode === "FREE";
+
+  const statusLabel = isFree
+    ? "Free Plan"
+    : cancelAtPeriodEnd
+      ? "Cancelling"
+      : "Active";
+
+  const renewalLabel = isFree
+    ? "—"
+    : cancelAtPeriodEnd
+      ? `Ends on`
+      : `Renews on`;
+
+  const renewalValue = isFree
+    ? "Upgrade to unlock more features"
+    : parseToDigitDate(Number(currentPeriodEnd));
+
+  return (
+    <LudoCard
+      shadow={false}
+      className="grid h-auto p-4 text-sm lg:text-md grid-cols-[2fr_1fr] grid-rows-4"
+    >
+      <p className="text-left">Current plan:</p>
+      <p className="text-right font-medium">{planCode}</p>
+
+      <p className="text-left">Status:</p>
+      <p
+        className={`text-right font-medium ${
+          cancelAtPeriodEnd ? "text-red-400" : "text-green-400"
+        }`}
+      >
+        {statusLabel}
+      </p>
+
+      <p className="text-left">{renewalLabel}</p>
+      <p className="text-right">{renewalValue}</p>
+
+      <div className="col-span-2 flex justify-between items-center">
+        <p className="text-left">
+          {isFree ? "Upgrade plan" : "Manage billing"}
+        </p>
+        <SubscriptionActionButton plan={planCode} />
+      </div>
+    </LudoCard>
+  );
+}

--- a/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
+++ b/apps/web/src/features/Hub/ProfileHub/Pages/AccountSettingsPage.tsx
@@ -15,6 +15,7 @@ import { useEditPreferences } from "@/hooks/Queries/Mutations/useEditPreferences
 import type { TogglePreferencesRequest } from "@ludocode/types";
 import { parseToDate } from "@ludocode/util";
 import { parseToDigitDate } from "@ludocode/util/date/dateUtils";
+import { SubscriptionStatusCard } from "../Components/Card/SubscriptionStatusCard";
 
 export function AccountSettingsPage() {
   const { data: user } = useSuspenseQuery(qo.currentUser());
@@ -24,7 +25,12 @@ export function AccountSettingsPage() {
   const userPfpSrc = getUserAvatar(avatarVersion, avatarIndex);
 
   const { data: subscription } = useSuspenseQuery(qo.subscription());
-  const { monthlyCreditAllowance, currentPeriodEnd, planCode } = subscription;
+  const {
+    monthlyCreditAllowance,
+    currentPeriodEnd,
+    planCode,
+    cancelAtPeriodEnd,
+  } = subscription;
   const renewalDate = parseToDigitDate(Number(currentPeriodEnd));
   const { data: aiCredits } = useSuspenseQuery(qo.credits());
 
@@ -77,10 +83,17 @@ export function AccountSettingsPage() {
 
         <ProfileCardContainer header="AI">
           <AICreditBalanceCard
-            planCode={planCode}
             remaining={aiCredits}
             allowance={monthlyCreditAllowance}
             renewalDate={renewalDate}
+          />
+        </ProfileCardContainer>
+
+        <ProfileCardContainer header="SUBSCRIPTION">
+          <SubscriptionStatusCard
+            planCode={planCode}
+            currentPeriodEnd={currentPeriodEnd}
+            cancelAtPeriodEnd={cancelAtPeriodEnd}
           />
         </ProfileCardContainer>
 


### PR DESCRIPTION
## Changes

- Added subscription status card to account settings page
- Removed manage plan / upgrade plan from ai credit overview and moved it to plan overview card

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Subscription Status Card to Account Settings displaying current plan, subscription status, renewal dates, and billing management options.

* **Improvements**
  * Removed "Need more?" action from AI Credit Balance Card for a cleaner interface.
  * Adjusted subscription-related button sizing for better visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->