### PR TITLE
feat(routes): Add already subscribed fallback route with redirect

### DIFF
--- a/apps/web/src/constants/ludoNavigation.tsx
+++ b/apps/web/src/constants/ludoNavigation.tsx
@@ -19,8 +19,9 @@ import { Route as lessonPageRoute } from "@/routes/_app/lesson/$courseId/$module
 import { Route as projectPageRoute } from "@/routes/_app/_desktopguard/project/$projectId.tsx";
 
 // SUBSCRIPTION
-import { Route as subscriptionComparisonRoute } from "@/routes/_app/subscription/comparison";
+import { Route as subscriptionComparisonRoute } from "@/routes/_app/subscription/_subscribedguard/comparison";
 import { Route as subscriptionConfirmedRoute } from "@/routes/_app/subscription/confirm";
+import { Route as alreadySubscribedRoute } from "@/routes/_app/subscription/already-subscribed";
 
 // SYNC + COMPLETION
 import { Route as syncRoute } from "@/routes/_app/sync/$lessonId.tsx";
@@ -107,6 +108,10 @@ export const ludoNavigation = {
     }),
     toSubscriptionConfirmedPage: () => ({
       to: subscriptionConfirmedRoute.to,
+    }),
+    toAlreadySubscribedPage: () => ({
+      to: alreadySubscribedRoute.to,
+      replace: true,
     }),
   },
 

--- a/apps/web/src/features/Subscription/Misc/AlreadySubscribedPage.tsx
+++ b/apps/web/src/features/Subscription/Misc/AlreadySubscribedPage.tsx
@@ -1,0 +1,61 @@
+import { ludoNavigation } from "@/constants/ludoNavigation";
+import { qo } from "@/hooks/Queries/Definitions/queries";
+import { useStripeManage } from "@/hooks/Queries/Mutations/useStripeManage";
+import { router } from "@/main";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+type AlreadySubscribedPageProps = {};
+
+export function AlreadySubscribedPage({}: AlreadySubscribedPageProps) {
+  const { data: currentCourseId } = useSuspenseQuery(qo.currentCourseId());
+  const { data: currentCourseProgress } = useSuspenseQuery(
+    qo.courseProgress(currentCourseId),
+  );
+
+  const navigateToCurrentModule = () => {
+    router.navigate(
+      ludoNavigation.hub.module.toModule(
+        currentCourseProgress.courseId,
+        currentCourseProgress.moduleId,
+      ),
+    );
+  };
+
+  const { openManagePortal } = useStripeManage();
+
+  return (
+    <div className="w-full h-full grid grid-cols-12">
+      <div className="col-span-1" />
+      <div className="col-span-10 flex flex-col items-center justify-center text-center gap-8 py-20">
+        <div className="flex flex-col gap-3 items-center">
+          <h1 className="text-2xl lg:text-3xl font-bold text-white">
+            Already subscribed!
+          </h1>
+
+          <p className="text-sm lg:text-base text-ludo-accent-muted max-w-md">
+            Looks like you're already subscribed!
+          </p>
+        </div>
+
+        <div className="flex gap-4">
+          <LudoButton
+            variant="alt"
+            className="px-4 w-auto"
+            onClick={() => navigateToCurrentModule()}
+          >
+            Back to App
+          </LudoButton>
+          <LudoButton
+            className="px-4 w-auto"
+            variant="white"
+            onClick={() => openManagePortal()}
+          >
+            Manage Plan
+          </LudoButton>
+        </div>
+      </div>
+      <div className="col-span-1" />
+    </div>
+  );
+}

--- a/apps/web/src/layouts/Fallback/SubscribedGuardPage.tsx
+++ b/apps/web/src/layouts/Fallback/SubscribedGuardPage.tsx
@@ -1,0 +1,12 @@
+import { AlreadySubscribedPage } from "@/features/Subscription/Misc/AlreadySubscribedPage";
+import { qo } from "@/hooks/Queries/Definitions/queries";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Outlet } from "@tanstack/react-router";
+
+export function SubscribedGuardPage() {
+  const { data: subscription } = useSuspenseQuery(qo.subscription());
+
+  if (subscription.planCode != "FREE") {
+    return <AlreadySubscribedPage />;
+  } else return <Outlet />;
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,11 +21,13 @@ import { Route as AppSyncLessonIdRouteImport } from './routes/_app/sync/$lessonI
 import { Route as AppSubscriptionSuccessRouteImport } from './routes/_app/subscription/success'
 import { Route as AppSubscriptionManageRouteImport } from './routes/_app/subscription/manage'
 import { Route as AppSubscriptionConfirmRouteImport } from './routes/_app/subscription/confirm'
-import { Route as AppSubscriptionComparisonRouteImport } from './routes/_app/subscription/comparison'
 import { Route as AppSubscriptionCancelRouteImport } from './routes/_app/subscription/cancel'
+import { Route as AppSubscriptionAlreadySubscribedRouteImport } from './routes/_app/subscription/already-subscribed'
 import { Route as AppOnboardingStageRouteImport } from './routes/_app/onboarding.$stage'
 import { Route as AppHubProjectsRouteImport } from './routes/_app/_hub/projects'
 import { Route as AppHubCoursesRouteImport } from './routes/_app/_hub/courses'
+import { Route as AppSubscriptionSubscribedguardRouteRouteImport } from './routes/_app/subscription/_subscribedguard/route'
+import { Route as AppSubscriptionSubscribedguardComparisonRouteImport } from './routes/_app/subscription/_subscribedguard/comparison'
 import { Route as AppHubProfileUserIdRouteImport } from './routes/_app/_hub/profile/$userId'
 import { Route as AppDesktopguardProjectProjectIdRouteImport } from './routes/_app/_desktopguard/project/$projectId'
 import { Route as AppHubProfileUserIdIndexRouteImport } from './routes/_app/_hub/profile/$userId/index'
@@ -92,17 +94,17 @@ const AppSubscriptionConfirmRoute = AppSubscriptionConfirmRouteImport.update({
   path: '/confirm',
   getParentRoute: () => AppSubscriptionRouteRoute,
 } as any)
-const AppSubscriptionComparisonRoute =
-  AppSubscriptionComparisonRouteImport.update({
-    id: '/comparison',
-    path: '/comparison',
-    getParentRoute: () => AppSubscriptionRouteRoute,
-  } as any)
 const AppSubscriptionCancelRoute = AppSubscriptionCancelRouteImport.update({
   id: '/cancel',
   path: '/cancel',
   getParentRoute: () => AppSubscriptionRouteRoute,
 } as any)
+const AppSubscriptionAlreadySubscribedRoute =
+  AppSubscriptionAlreadySubscribedRouteImport.update({
+    id: '/already-subscribed',
+    path: '/already-subscribed',
+    getParentRoute: () => AppSubscriptionRouteRoute,
+  } as any)
 const AppOnboardingStageRoute = AppOnboardingStageRouteImport.update({
   id: '/onboarding/$stage',
   path: '/onboarding/$stage',
@@ -118,6 +120,17 @@ const AppHubCoursesRoute = AppHubCoursesRouteImport.update({
   path: '/courses',
   getParentRoute: () => AppHubRouteRoute,
 } as any)
+const AppSubscriptionSubscribedguardRouteRoute =
+  AppSubscriptionSubscribedguardRouteRouteImport.update({
+    id: '/_subscribedguard',
+    getParentRoute: () => AppSubscriptionRouteRoute,
+  } as any)
+const AppSubscriptionSubscribedguardComparisonRoute =
+  AppSubscriptionSubscribedguardComparisonRouteImport.update({
+    id: '/comparison',
+    path: '/comparison',
+    getParentRoute: () => AppSubscriptionSubscribedguardRouteRoute,
+  } as any)
 const AppHubProfileUserIdRoute = AppHubProfileUserIdRouteImport.update({
   id: '/profile/$userId',
   path: '/profile/$userId',
@@ -167,7 +180,7 @@ const AppLessonCourseIdModuleIdLessonIdIndexRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
-  '/subscription': typeof AppSubscriptionRouteRouteWithChildren
+  '/subscription': typeof AppSubscriptionSubscribedguardRouteRouteWithChildren
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
   '/': typeof AppIndexRoute
@@ -175,14 +188,15 @@ export interface FileRoutesByFullPath {
   '/courses': typeof AppHubCoursesRoute
   '/projects': typeof AppHubProjectsRoute
   '/onboarding/$stage': typeof AppOnboardingStageRoute
+  '/subscription/already-subscribed': typeof AppSubscriptionAlreadySubscribedRoute
   '/subscription/cancel': typeof AppSubscriptionCancelRoute
-  '/subscription/comparison': typeof AppSubscriptionComparisonRoute
   '/subscription/confirm': typeof AppSubscriptionConfirmRoute
   '/subscription/manage': typeof AppSubscriptionManageRoute
   '/subscription/success': typeof AppSubscriptionSuccessRoute
   '/sync/$lessonId': typeof AppSyncLessonIdRoute
   '/project/$projectId': typeof AppDesktopguardProjectProjectIdRoute
   '/profile/$userId': typeof AppHubProfileUserIdRouteWithChildren
+  '/subscription/comparison': typeof AppSubscriptionSubscribedguardComparisonRoute
   '/lesson/$courseId/$moduleId/$lessonId': typeof AppLessonCourseIdModuleIdLessonIdRouteRouteWithChildren
   '/learn/$courseId/$moduleId': typeof AppHubLearnCourseIdModuleIdRoute
   '/profile/$userId/settings': typeof AppHubProfileUserIdSettingsRoute
@@ -191,7 +205,7 @@ export interface FileRoutesByFullPath {
   '/lesson/$courseId/$moduleId/$lessonId/': typeof AppLessonCourseIdModuleIdLessonIdIndexRoute
 }
 export interface FileRoutesByTo {
-  '/subscription': typeof AppSubscriptionRouteRouteWithChildren
+  '/subscription': typeof AppSubscriptionSubscribedguardRouteRouteWithChildren
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
   '/': typeof AppIndexRoute
@@ -199,13 +213,14 @@ export interface FileRoutesByTo {
   '/courses': typeof AppHubCoursesRoute
   '/projects': typeof AppHubProjectsRoute
   '/onboarding/$stage': typeof AppOnboardingStageRoute
+  '/subscription/already-subscribed': typeof AppSubscriptionAlreadySubscribedRoute
   '/subscription/cancel': typeof AppSubscriptionCancelRoute
-  '/subscription/comparison': typeof AppSubscriptionComparisonRoute
   '/subscription/confirm': typeof AppSubscriptionConfirmRoute
   '/subscription/manage': typeof AppSubscriptionManageRoute
   '/subscription/success': typeof AppSubscriptionSuccessRoute
   '/sync/$lessonId': typeof AppSyncLessonIdRoute
   '/project/$projectId': typeof AppDesktopguardProjectProjectIdRoute
+  '/subscription/comparison': typeof AppSubscriptionSubscribedguardComparisonRoute
   '/learn/$courseId/$moduleId': typeof AppHubLearnCourseIdModuleIdRoute
   '/profile/$userId/settings': typeof AppHubProfileUserIdSettingsRoute
   '/completion/$courseId/$moduleId/$lessonId': typeof AppCompletionCourseIdModuleIdLessonIdRoute
@@ -222,17 +237,19 @@ export interface FileRoutesById {
   '/auth/register': typeof AuthRegisterRoute
   '/_app/': typeof AppIndexRoute
   '/demo/': typeof DemoIndexRoute
+  '/_app/subscription/_subscribedguard': typeof AppSubscriptionSubscribedguardRouteRouteWithChildren
   '/_app/_hub/courses': typeof AppHubCoursesRoute
   '/_app/_hub/projects': typeof AppHubProjectsRoute
   '/_app/onboarding/$stage': typeof AppOnboardingStageRoute
+  '/_app/subscription/already-subscribed': typeof AppSubscriptionAlreadySubscribedRoute
   '/_app/subscription/cancel': typeof AppSubscriptionCancelRoute
-  '/_app/subscription/comparison': typeof AppSubscriptionComparisonRoute
   '/_app/subscription/confirm': typeof AppSubscriptionConfirmRoute
   '/_app/subscription/manage': typeof AppSubscriptionManageRoute
   '/_app/subscription/success': typeof AppSubscriptionSuccessRoute
   '/_app/sync/$lessonId': typeof AppSyncLessonIdRoute
   '/_app/_desktopguard/project/$projectId': typeof AppDesktopguardProjectProjectIdRoute
   '/_app/_hub/profile/$userId': typeof AppHubProfileUserIdRouteWithChildren
+  '/_app/subscription/_subscribedguard/comparison': typeof AppSubscriptionSubscribedguardComparisonRoute
   '/_app/lesson/$courseId/$moduleId/$lessonId': typeof AppLessonCourseIdModuleIdLessonIdRouteRouteWithChildren
   '/_app/_hub/learn/$courseId/$moduleId': typeof AppHubLearnCourseIdModuleIdRoute
   '/_app/_hub/profile/$userId/settings': typeof AppHubProfileUserIdSettingsRoute
@@ -251,14 +268,15 @@ export interface FileRouteTypes {
     | '/courses'
     | '/projects'
     | '/onboarding/$stage'
+    | '/subscription/already-subscribed'
     | '/subscription/cancel'
-    | '/subscription/comparison'
     | '/subscription/confirm'
     | '/subscription/manage'
     | '/subscription/success'
     | '/sync/$lessonId'
     | '/project/$projectId'
     | '/profile/$userId'
+    | '/subscription/comparison'
     | '/lesson/$courseId/$moduleId/$lessonId'
     | '/learn/$courseId/$moduleId'
     | '/profile/$userId/settings'
@@ -275,13 +293,14 @@ export interface FileRouteTypes {
     | '/courses'
     | '/projects'
     | '/onboarding/$stage'
+    | '/subscription/already-subscribed'
     | '/subscription/cancel'
-    | '/subscription/comparison'
     | '/subscription/confirm'
     | '/subscription/manage'
     | '/subscription/success'
     | '/sync/$lessonId'
     | '/project/$projectId'
+    | '/subscription/comparison'
     | '/learn/$courseId/$moduleId'
     | '/profile/$userId/settings'
     | '/completion/$courseId/$moduleId/$lessonId'
@@ -297,17 +316,19 @@ export interface FileRouteTypes {
     | '/auth/register'
     | '/_app/'
     | '/demo/'
+    | '/_app/subscription/_subscribedguard'
     | '/_app/_hub/courses'
     | '/_app/_hub/projects'
     | '/_app/onboarding/$stage'
+    | '/_app/subscription/already-subscribed'
     | '/_app/subscription/cancel'
-    | '/_app/subscription/comparison'
     | '/_app/subscription/confirm'
     | '/_app/subscription/manage'
     | '/_app/subscription/success'
     | '/_app/sync/$lessonId'
     | '/_app/_desktopguard/project/$projectId'
     | '/_app/_hub/profile/$userId'
+    | '/_app/subscription/_subscribedguard/comparison'
     | '/_app/lesson/$courseId/$moduleId/$lessonId'
     | '/_app/_hub/learn/$courseId/$moduleId'
     | '/_app/_hub/profile/$userId/settings'
@@ -409,18 +430,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSubscriptionConfirmRouteImport
       parentRoute: typeof AppSubscriptionRouteRoute
     }
-    '/_app/subscription/comparison': {
-      id: '/_app/subscription/comparison'
-      path: '/comparison'
-      fullPath: '/subscription/comparison'
-      preLoaderRoute: typeof AppSubscriptionComparisonRouteImport
-      parentRoute: typeof AppSubscriptionRouteRoute
-    }
     '/_app/subscription/cancel': {
       id: '/_app/subscription/cancel'
       path: '/cancel'
       fullPath: '/subscription/cancel'
       preLoaderRoute: typeof AppSubscriptionCancelRouteImport
+      parentRoute: typeof AppSubscriptionRouteRoute
+    }
+    '/_app/subscription/already-subscribed': {
+      id: '/_app/subscription/already-subscribed'
+      path: '/already-subscribed'
+      fullPath: '/subscription/already-subscribed'
+      preLoaderRoute: typeof AppSubscriptionAlreadySubscribedRouteImport
       parentRoute: typeof AppSubscriptionRouteRoute
     }
     '/_app/onboarding/$stage': {
@@ -443,6 +464,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/courses'
       preLoaderRoute: typeof AppHubCoursesRouteImport
       parentRoute: typeof AppHubRouteRoute
+    }
+    '/_app/subscription/_subscribedguard': {
+      id: '/_app/subscription/_subscribedguard'
+      path: ''
+      fullPath: '/subscription'
+      preLoaderRoute: typeof AppSubscriptionSubscribedguardRouteRouteImport
+      parentRoute: typeof AppSubscriptionRouteRoute
+    }
+    '/_app/subscription/_subscribedguard/comparison': {
+      id: '/_app/subscription/_subscribedguard/comparison'
+      path: '/comparison'
+      fullPath: '/subscription/comparison'
+      preLoaderRoute: typeof AppSubscriptionSubscribedguardComparisonRouteImport
+      parentRoute: typeof AppSubscriptionSubscribedguardRouteRoute
     }
     '/_app/_hub/profile/$userId': {
       id: '/_app/_hub/profile/$userId'
@@ -545,17 +580,35 @@ const AppHubRouteRouteWithChildren = AppHubRouteRoute._addFileChildren(
   AppHubRouteRouteChildren,
 )
 
+interface AppSubscriptionSubscribedguardRouteRouteChildren {
+  AppSubscriptionSubscribedguardComparisonRoute: typeof AppSubscriptionSubscribedguardComparisonRoute
+}
+
+const AppSubscriptionSubscribedguardRouteRouteChildren: AppSubscriptionSubscribedguardRouteRouteChildren =
+  {
+    AppSubscriptionSubscribedguardComparisonRoute:
+      AppSubscriptionSubscribedguardComparisonRoute,
+  }
+
+const AppSubscriptionSubscribedguardRouteRouteWithChildren =
+  AppSubscriptionSubscribedguardRouteRoute._addFileChildren(
+    AppSubscriptionSubscribedguardRouteRouteChildren,
+  )
+
 interface AppSubscriptionRouteRouteChildren {
+  AppSubscriptionSubscribedguardRouteRoute: typeof AppSubscriptionSubscribedguardRouteRouteWithChildren
+  AppSubscriptionAlreadySubscribedRoute: typeof AppSubscriptionAlreadySubscribedRoute
   AppSubscriptionCancelRoute: typeof AppSubscriptionCancelRoute
-  AppSubscriptionComparisonRoute: typeof AppSubscriptionComparisonRoute
   AppSubscriptionConfirmRoute: typeof AppSubscriptionConfirmRoute
   AppSubscriptionManageRoute: typeof AppSubscriptionManageRoute
   AppSubscriptionSuccessRoute: typeof AppSubscriptionSuccessRoute
 }
 
 const AppSubscriptionRouteRouteChildren: AppSubscriptionRouteRouteChildren = {
+  AppSubscriptionSubscribedguardRouteRoute:
+    AppSubscriptionSubscribedguardRouteRouteWithChildren,
+  AppSubscriptionAlreadySubscribedRoute: AppSubscriptionAlreadySubscribedRoute,
   AppSubscriptionCancelRoute: AppSubscriptionCancelRoute,
-  AppSubscriptionComparisonRoute: AppSubscriptionComparisonRoute,
   AppSubscriptionConfirmRoute: AppSubscriptionConfirmRoute,
   AppSubscriptionManageRoute: AppSubscriptionManageRoute,
   AppSubscriptionSuccessRoute: AppSubscriptionSuccessRoute,

--- a/apps/web/src/routes/_app/subscription/_subscribedguard/comparison.tsx
+++ b/apps/web/src/routes/_app/subscription/_subscribedguard/comparison.tsx
@@ -1,6 +1,6 @@
 import { SubscriptionComparisonPage } from "@/features/Subscription/Comparison/SubscriptionComparisonPage";
 import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/_app/subscription/comparison")({
+export const Route = createFileRoute("/_app/subscription/_subscribedguard/comparison")({
   component: SubscriptionComparisonPage,
 });

--- a/apps/web/src/routes/_app/subscription/_subscribedguard/route.tsx
+++ b/apps/web/src/routes/_app/subscription/_subscribedguard/route.tsx
@@ -1,0 +1,15 @@
+import { ludoNavigation } from "@/constants/ludoNavigation";
+import { qo } from "@/hooks/Queries/Definitions/queries";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_app/subscription/_subscribedguard")({
+  beforeLoad: async ({ context }) => {
+    const currentSubscription = await context.queryClient.ensureQueryData(
+      qo.subscription(),
+    );
+
+    if (currentSubscription.planCode != "FREE") {
+      throw redirect(ludoNavigation.subscription.toAlreadySubscribedPage());
+    }
+  },
+});

--- a/apps/web/src/routes/_app/subscription/already-subscribed.tsx
+++ b/apps/web/src/routes/_app/subscription/already-subscribed.tsx
@@ -1,0 +1,6 @@
+import { AlreadySubscribedPage } from '@/features/Subscription/Misc/AlreadySubscribedPage'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_app/subscription/already-subscribed')({
+  component: AlreadySubscribedPage,
+})


### PR DESCRIPTION
## Changes

- Added `/subscription/_subscriptionguard` route whose route.tsx checks if a user is subscribed before load
  - If user is subscribed, it throws a redirect to `/subscription/already-subscribed`
  - Otherwise, it takes the user to the route they intended to go to

-  Moved `/subscription/comparison` to `/subscription/_subscriptionguard` route (so that subscribed users cant make new subscriptions)
- Created `already-subscribed` route with `AlreadySubscribedPage` prompting the user to either go back to the app or manage their plan

## Related Issues

- Closes #261 

## Screenshots

<img width="776" height="676" alt="image" src="https://github.com/user-attachments/assets/61978f0b-f81d-4479-b69f-68568e44b039" />

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a route guard that detects when users are already subscribed and redirects them to an "Already Subscribed" page.
  * Introduced a dedicated page for subscribed users with options to return to the app or manage their subscription plan.
  * Reorganized subscription routes to include protective guards ensuring appropriate user access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->