### PR TITLE
feat(curriculum): Add change subject & language actions

### DIFF
--- a/apps/admin/src/features/Curriculum/Components/Dialog/ChangeLanguageDialog.tsx
+++ b/apps/admin/src/features/Curriculum/Components/Dialog/ChangeLanguageDialog.tsx
@@ -1,0 +1,107 @@
+import { DialogTitle } from "@ludocode/external/ui/dialog";
+import { type ReactNode, useEffect, useState } from "react";
+import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import { Spinner } from "@ludocode/external/ui/spinner";
+import {
+  LudoSelect,
+  LudoSelectItem,
+} from "@ludocode/design-system/primitives/select";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { qo } from "@/hooks/Queries/Definitions/queries";
+import { useChangeLanguage } from "../../Hooks/useChangeLanguage";
+
+type ChangeLanguageDialogProps = {
+  open: boolean;
+  close: () => void;
+  children: ReactNode;
+  courseId: string;
+  currentLanguageId?: number;
+};
+
+export function ChangeLanguageDialog({
+  open,
+  close,
+  children,
+  courseId,
+  currentLanguageId,
+}: ChangeLanguageDialogProps) {
+  const { data: languages } = useSuspenseQuery(qo.languages());
+
+  const changeMutation = useChangeLanguage({ courseId });
+
+  const [selectedLanguageId, setSelectedLanguageId] = useState<number>(0);
+
+  const hasChanged = currentLanguageId !== selectedLanguageId;
+
+  useEffect(() => {
+    if (open) {
+      setSelectedLanguageId(currentLanguageId ?? 0);
+    }
+  }, [open, currentLanguageId]);
+
+  const isLoading = changeMutation.isPending;
+
+  const handleSubmit = () => {
+    if (!hasChanged) {
+      close();
+      return;
+    }
+
+    changeMutation.mutate(
+      { languageId: selectedLanguageId },
+      {
+        onSuccess: () => {
+          close();
+        },
+      },
+    );
+  };
+
+  return (
+    <LudoDialog
+      trigger={children}
+      open={open}
+      onOpenChange={(next) => {
+        if (next) return;
+        close();
+      }}
+    >
+      <DialogTitle className="text-white font-bold text-xl">
+        Change Language
+      </DialogTitle>
+
+      <div className="flex flex-col gap-6 mt-4">
+        <LudoSelect
+          variant="dark"
+          title="Language"
+          value={selectedLanguageId.toString()}
+          setValue={(v) => setSelectedLanguageId(Number(v))}
+        >
+          {languages.map((lang) => (
+            <LudoSelectItem key={lang.languageId} value={lang.languageId.toString()}>
+              <span className="flex items-center gap-2">
+                <span>{lang.name}</span>
+                {lang.slug && (
+                  <span className="text-xs text-ludoAltText">
+                    /{lang.slug}
+                  </span>
+                )}
+              </span>
+            </LudoSelectItem>
+          ))}
+        </LudoSelect>
+
+        <LudoButton
+          disabled={isLoading || !selectedLanguageId}
+          variant="alt"
+          onClick={handleSubmit}
+          className="w-full flex justify-center"
+        >
+          {hasChanged ? "Change Language" : "Exit"}
+          {isLoading && <Spinner className="ml-2 text-ludo-accent-muted" />}
+        </LudoButton>
+      </div>
+    </LudoDialog>
+  );
+}

--- a/apps/admin/src/features/Curriculum/Components/Dialog/ChangeSubjectDialog.tsx
+++ b/apps/admin/src/features/Curriculum/Components/Dialog/ChangeSubjectDialog.tsx
@@ -1,0 +1,104 @@
+import { DialogTitle } from "@ludocode/external/ui/dialog";
+import { type ReactNode, useEffect, useState } from "react";
+import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import { Spinner } from "@ludocode/external/ui/spinner";
+import {
+  LudoSelect,
+  LudoSelectItem,
+} from "@ludocode/design-system/primitives/select";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { qo } from "@/hooks/Queries/Definitions/queries";
+import { useChangeSubject } from "../../Hooks/useChangeSubject";
+
+type ChangeSubjectDialogProps = {
+  open: boolean;
+  close: () => void;
+  children: ReactNode;
+  courseId: string;
+  currentSubjectSlug?: string;
+};
+
+export function ChangeSubjectDialog({
+  open,
+  close,
+  children,
+  courseId,
+  currentSubjectSlug,
+}: ChangeSubjectDialogProps) {
+  const { data: subjects } = useSuspenseQuery(qo.allSubjects());
+  const changeMutation = useChangeSubject({ courseId });
+
+  const [selectedSlug, setSelectedSlug] = useState<string>("");
+
+  const hasChanged = currentSubjectSlug !== selectedSlug;
+
+  useEffect(() => {
+    if (open) {
+      setSelectedSlug(currentSubjectSlug ?? "");
+    }
+  }, [open, currentSubjectSlug]);
+
+  const isLoading = changeMutation.isPending;
+
+  const handleSubmit = () => {
+    if (!hasChanged) {
+      close();
+      return;
+    }
+    const selected = subjects.find((s) => s.slug === selectedSlug);
+    if (!selected) return;
+
+    changeMutation.mutate(
+      { subjectId: selected.id },
+      {
+        onSuccess: () => {
+          close();
+        },
+      },
+    );
+  };
+
+  return (
+    <LudoDialog
+      trigger={children}
+      open={open}
+      onOpenChange={(next) => {
+        if (next) return;
+        close();
+      }}
+    >
+      <DialogTitle className="text-white font-bold text-xl">
+        Change Subject
+      </DialogTitle>
+
+      <div className="flex flex-col gap-6 mt-4">
+        <LudoSelect
+          variant="dark"
+          title="Subject"
+          value={selectedSlug}
+          setValue={setSelectedSlug}
+        >
+          {subjects.map((s) => (
+            <LudoSelectItem key={s.id} value={s.slug}>
+              <span className="flex items-center gap-2">
+                <span>{s.name}</span>
+                <span className="text-xs text-ludoAltText">/{s.slug}</span>
+              </span>
+            </LudoSelectItem>
+          ))}
+        </LudoSelect>
+
+        <LudoButton
+          disabled={isLoading || !selectedSlug}
+          variant="alt"
+          onClick={handleSubmit}
+          className="w-full flex justify-center"
+        >
+          {hasChanged ? "Change Subject" : "Exit"}
+          {isLoading && <Spinner className="ml-2 text-ludo-accent-muted" />}
+        </LudoButton>
+      </div>
+    </LudoDialog>
+  );
+}

--- a/apps/admin/src/features/Curriculum/Components/Zone/CurriculumHero.tsx
+++ b/apps/admin/src/features/Curriculum/Components/Zone/CurriculumHero.tsx
@@ -1,21 +1,95 @@
 import { CustomIcon } from "@ludocode/design-system/primitives/custom-icon";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import type { LanguageMetadata, LudoCourseSubject } from "@ludocode/types";
 import { ArrowLeftRight } from "lucide-react";
+import { ChangeSubjectDialog } from "../Dialog/ChangeSubjectDialog";
+import { ChangeLanguageDialog } from "../Dialog/ChangeLanguageDialog";
+import { useState } from "react";
 
-type CurriculumHeroProps = {};
+type CurriculumHeroProps = {
+  courseId: string;
+  courseSubject?: LudoCourseSubject;
+  courseLanguage?: LanguageMetadata;
+};
 
-export function CurriculumHero({}: CurriculumHeroProps) {
+export function CurriculumHero({
+  courseId,
+  courseSubject,
+  courseLanguage,
+}: CurriculumHeroProps) {
+  const [openSubjectModal, setOpenSubjectModal] = useState(false);
+  const [openLanguageModal, setOpenLanguageModal] = useState(false);
+
   return (
-    <div className="flex gap-4 text-lg font-bold text-white items-center">
-      <CustomIcon color="white" className="h-6 w-6" iconName="Python" />
-      <p>Subject: Python</p>
-      <LudoButton
-        className="w-auto h-auto px-4 py-1 rounded-sm"
-        shadow={false}
-        variant="alt"
-      >
-        <ArrowLeftRight className="h-4 w-4" />{" "}
-      </LudoButton>
+    <div className="flex flex-col gap-6">
+      {/* META CARDS ROW */}
+      <div className="grid grid-cols-2 gap-4">
+        {/* SUBJECT CARD */}
+        <div className="flex items-center justify-between bg-ludo-background border border-ludo-border rounded-lg px-4 py-3">
+          <div className="flex flex-col">
+            <span className="text-xs text-ludoAltText uppercase tracking-wide">
+              Subject
+            </span>
+            <span className="text-white font-semibold">
+              {courseSubject?.name ?? "No Subject"}
+            </span>
+            <span className="text-xs text-ludo-accent-muted">
+              {courseSubject ? `/${courseSubject.slug}` : "-"}
+            </span>
+          </div>
+
+          {courseSubject && (
+            <ChangeSubjectDialog
+              open={openSubjectModal}
+              close={() => setOpenSubjectModal(false)}
+              courseId={courseId}
+              currentSubjectSlug={courseSubject.slug}
+            >
+              <LudoButton
+                onClick={() => setOpenSubjectModal(true)}
+                variant="alt"
+                shadow={false}
+                className="px-3 py-2 w-10"
+              >
+                <ArrowLeftRight className="h-4 w-4" />
+              </LudoButton>
+            </ChangeSubjectDialog>
+          )}
+        </div>
+
+        {/* LANGUAGE CARD */}
+        <div className="flex items-center justify-between bg-ludo-background border border-ludo-border rounded-lg px-4 py-3">
+          <div className="flex flex-col">
+            <span className="text-xs text-ludoAltText uppercase tracking-wide">
+              Language
+            </span>
+            <span className="text-white font-semibold">
+              {courseLanguage?.name ?? "No Language"}
+            </span>
+            <span className="text-xs text-ludo-accent-muted">
+              {courseLanguage?.slug ? `/${courseLanguage.slug}` : "-"}
+            </span>
+          </div>
+
+          {courseLanguage && (
+            <ChangeLanguageDialog
+              open={openLanguageModal}
+              close={() => setOpenLanguageModal(false)}
+              courseId={courseId}
+              currentLanguageId={courseLanguage.languageId}
+            >
+              <LudoButton
+                onClick={() => setOpenLanguageModal(true)}
+                variant="alt"
+                shadow={false}
+                className="px-3 py-2 w-10"
+              >
+                <ArrowLeftRight className="h-4 w-4" />
+              </LudoButton>
+            </ChangeLanguageDialog>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/features/Curriculum/CurriculumPage.tsx
+++ b/apps/admin/src/features/Curriculum/CurriculumPage.tsx
@@ -29,6 +29,12 @@ export function CurriculumPage({}: CurriculumPageProps) {
   const courseName =
     courses.find((c) => c.id === courseId)?.title ?? "Untitled Course";
 
+  const courseSubject =
+    courses.find((c) => c.id === courseId)?.subject;
+
+  const courseLanguage = 
+    courses.find((c) => c.id == courseId)?.language
+
   const [isEditing, setIsEditing] = useState(false);
 
   const submitMutation = useUpdateCourse({
@@ -92,7 +98,7 @@ export function CurriculumPage({}: CurriculumPageProps) {
               courseName={courseName}
             />
             <h1 className="text-white text-3xl font-bold">{courseName}</h1>
-            <CurriculumHero />
+            <CurriculumHero courseLanguage={courseLanguage} courseId={courseId} courseSubject={courseSubject} />
           </div>
         </div>
 

--- a/apps/admin/src/features/Curriculum/Hooks/useChangeLanguage.tsx
+++ b/apps/admin/src/features/Curriculum/Hooks/useChangeLanguage.tsx
@@ -1,0 +1,19 @@
+import { mutations } from "@/hooks/Queries/Definitions/mutations";
+import { qk } from "@/hooks/Queries/Definitions/qk";
+import type { LudoCourse } from "@ludocode/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type Args = {
+  courseId: string;
+};
+
+export function useChangeLanguage({ courseId }: Args) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    ...mutations.changeCourseLanguage(courseId),
+    onSuccess: (payload: LudoCourse[]) => {
+      qc.setQueryData(qk.courses(), payload);
+    },
+  });
+}

--- a/apps/admin/src/features/Curriculum/Hooks/useChangeSubject.tsx
+++ b/apps/admin/src/features/Curriculum/Hooks/useChangeSubject.tsx
@@ -1,0 +1,19 @@
+import { mutations } from "@/hooks/Queries/Definitions/mutations.ts";
+import { qk } from "@/hooks/Queries/Definitions/qk.ts";
+import type { LudoCourse } from "@ludocode/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type Args = {
+  courseId: string;
+};
+
+export function useChangeSubject({ courseId }: Args) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    ...mutations.changeCourseSubject(courseId),
+    onSuccess: (payload: LudoCourse[]) => {
+      qc.setQueryData(qk.courses(), payload);
+    },
+  });
+}

--- a/apps/admin/src/hooks/Queries/Definitions/mutations.ts
+++ b/apps/admin/src/hooks/Queries/Definitions/mutations.ts
@@ -4,6 +4,8 @@ import { type CreateCourseRequest } from "@ludocode/types/Builder/CreateCourseRe
 import { ludoDelete, ludoPost, ludoPut } from "@ludocode/api/fetcher";
 import { adminApi } from "@/constants/api/adminApi";
 import {
+  type ChangeLanguageRequest,
+  type ChangeSubjectRequest,
   type CurriculumDraft,
   type CurriculumDraftLessonForm,
   type LanguageMetadata,
@@ -96,6 +98,28 @@ export const mutations = {
         ),
     });
   },
+  changeCourseSubject: (courseId: string) => {
+    return mutationOptions<LudoCourse[], Error, ChangeSubjectRequest>({
+      mutationKey: ["changeCourseSubject"],
+      mutationFn: (variables) =>
+        ludoPut<LudoCourse[], ChangeSubjectRequest>(
+          adminApi.snapshots.byCourseCurriculumSubject(courseId),
+          variables,
+          true,
+        ),
+    });
+  },
+  changeCourseLanguage: (courseId: string) => {
+    return mutationOptions<LudoCourse[], Error, ChangeLanguageRequest>({
+      mutationKey: ["changeCourseLanguage"],
+      mutationFn: (variables) =>
+        ludoPut<LudoCourse[], ChangeLanguageRequest>(
+          adminApi.snapshots.byCourseCurriculumLanguage(courseId),
+          variables,
+          true,
+        ),
+    });
+  },
   deleteSubject: (subjectid: number) => {
     return mutationOptions<SubjectsDraftSnapshot[], Error, void>({
       mutationKey: ["deleteSubject"],
@@ -107,7 +131,11 @@ export const mutations = {
     });
   },
   createSubject: () => {
-    return mutationOptions<SubjectsDraftSnapshot[], Error, SubjectsDraftSnapshot>({
+    return mutationOptions<
+      SubjectsDraftSnapshot[],
+      Error,
+      SubjectsDraftSnapshot
+    >({
       mutationKey: ["createSubject"],
       mutationFn: (variables) =>
         ludoPost<SubjectsDraftSnapshot[], SubjectsDraftSnapshot>(

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -61,8 +61,10 @@ export function createApiPaths({
       base: `${BASE}/lessons`,
       adminBase: `${ADMIN_BASE}/lessons`,
       lessons: (lessonIds: string) => `${BASE}/lessons?${lessonIds}`,
-      lessonExercises: (lessonId: string) => `${BASE}/lessons/${lessonId}/exercises`,
-      byLessonCurriculum: (lessonId: string) => `${ADMIN_BASE}/lessons/${lessonId}`
+      lessonExercises: (lessonId: string) =>
+        `${BASE}/lessons/${lessonId}/exercises`,
+      byLessonCurriculum: (lessonId: string) =>
+        `${ADMIN_BASE}/lessons/${lessonId}`,
     },
 
     progress: {
@@ -106,6 +108,10 @@ export function createApiPaths({
       course: `${ADMIN_BASE}/snapshots/course`,
       byCourseCurriculum: (courseId: string) =>
         `${ADMIN_BASE}/snapshots/curriculum/${courseId}`,
+      byCourseCurriculumSubject: (courseId: string) =>
+        `${ADMIN_BASE}/snapshots/${courseId}/subject`,
+      byCourseCurriculumLanguage: (courseId: string) =>
+        `${ADMIN_BASE}/snapshots/${courseId}/language`,
       byCourse: (courseId: string) => `${ADMIN_BASE}/snapshots/${courseId}`,
     },
 
@@ -121,7 +127,7 @@ export function createApiPaths({
       checkout: `${BASE}/subscription/checkout`,
       confirm: `${BASE}/subscription/confirm`,
       manage: `${BASE}/subscription/manage`,
-      plans: `${BASE}/subscription/plans`
+      plans: `${BASE}/subscription/plans`,
     },
 
     preferences: {

--- a/packages/design-system/primitives/select.tsx
+++ b/packages/design-system/primitives/select.tsx
@@ -6,6 +6,7 @@ type LudoSelectProps = {
   value: string;
   setValue: (v: string) => void;
   title?: string;
+  variant?: "default" | "dark";
   children: React.ReactNode;
   containerClassName?: string;
   error?: string;
@@ -15,10 +16,14 @@ export function LudoSelect({
   value,
   setValue,
   title,
+  variant = "default",
   children,
   containerClassName,
   error,
 }: LudoSelectProps) {
+  const variantStyle =
+    variant == "default" ? "bg-ludo-surface" : "bg-ludo-background";
+
   return (
     <div
       className={cn(
@@ -32,10 +37,11 @@ export function LudoSelect({
         <Select.Trigger
           className={cn(
             "h-12 w-full rounded-md px-3",
-            "bg-ludo-surface text-white",
+            "text-white",
             "border border-transparent",
             "flex items-center justify-between",
             error && "border-red-400",
+            variantStyle,
           )}
         >
           <Select.Value placeholder="Select…" />
@@ -54,7 +60,8 @@ export function LudoSelect({
             className={cn(
               "z-50 rounded-md overflow-hidden rounded-md",
               "border-4 p-2 border-ludo-accent",
-              "bg-ludo-surface shadow-lg",
+              "shadow-lg",
+              variantStyle,
             )}
           >
             <Select.Viewport className="p-1 max-h-50 overflow-y-auto">

--- a/packages/types/Curriculum/ChangeSubjectRequest.ts
+++ b/packages/types/Curriculum/ChangeSubjectRequest.ts
@@ -1,0 +1,3 @@
+export type ChangeSubjectRequest = {
+    subjectId: number
+}

--- a/packages/types/Languages/ChangeLanguageRequest.ts
+++ b/packages/types/Languages/ChangeLanguageRequest.ts
@@ -1,0 +1,3 @@
+export type ChangeLanguageRequest = {
+  languageId: number;
+};

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -21,6 +21,7 @@ export * from "./Completion/SyncState";
 // Curriculum
 export * from "./Curriculum/CurriculumDraftSchema";
 export * from "./Curriculum/SubjectDraftSchema"
+export * from "./Curriculum/ChangeSubjectRequest"
 
 // Exercise
 export * from "./Exercise/AnswerToken";
@@ -35,6 +36,7 @@ export * from "./FeatureFlags/FeatureFlags";
 // Languages
 export * from "./Languages/ModifyLanguageRequest";
 export * from "./Languages/CreateLanguageFormSchema";
+export * from "./Languages/ChangeLanguageRequest";
 
 // Onboarding
 export * from "./Onboarding/OnboardingCourse";


### PR DESCRIPTION
## Changes

- The course page in the curriculum now displays the courses language & subject
- Users can click a button to switch either, which displays a modal with a select component for the respective property
- Added mutations for the respective actions

## Related Issues

- Closes #234 

## Screenshots
<img width="1357" height="791" alt="image" src="https://github.com/user-attachments/assets/e02cf926-9e90-4b45-bcaf-81874f3e333f" />
<img width="1367" height="794" alt="image" src="https://github.com/user-attachments/assets/fc79055a-eb2e-47fd-a659-3c896f78fcc0" />
<img width="1374" height="797" alt="image" src="https://github.com/user-attachments/assets/990b2916-d515-4206-ae37-325ddc812605" />



## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to change course language through a dedicated dialog interface.
  * Added ability to change course subject through a dedicated dialog interface.
  * Enhanced curriculum page header to display current language and subject with edit options.
  * Extended select component styling with dark theme variant for better visual consistency in dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->