### PR TITLE
feat(curriculum editor): Add create course dialog with mutation

### DIFF
--- a/apps/admin/src/features/CoursesHub/Components/Dialog/CreateCourseDialog.tsx
+++ b/apps/admin/src/features/CoursesHub/Components/Dialog/CreateCourseDialog.tsx
@@ -1,0 +1,159 @@
+import { DialogTitle } from "@ludocode/external/ui/dialog";
+import { type ReactNode, useState } from "react";
+import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import { LudoInput } from "@ludocode/design-system/primitives/input";
+import { Spinner } from "@ludocode/external/ui/spinner";
+import {
+  LudoSelect,
+  LudoSelectItem,
+} from "@ludocode/design-system/primitives/select";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { qo } from "@/hooks/Queries/Definitions/queries";
+import { useCreateCourse } from "@/hooks/Queries/Mutations/useCreateCourse";
+import { createCourseSchema, type CourseType } from "@ludocode/types";
+
+type Props = {
+  open: boolean;
+  close: () => void;
+  children: ReactNode;
+};
+
+export function CreateCourseDialog({ open, close, children }: Props) {
+  const { data: subjects } = useSuspenseQuery(qo.allSubjects());
+  const { data: languages } = useSuspenseQuery(qo.languages());
+
+  const createMutation = useCreateCourse();
+
+  const [courseTitle, setCourseTitle] = useState("");
+  const [courseSubjectId, setCourseSubjectId] = useState<number>(0);
+  const [languageId, setLanguageId] = useState<number | undefined>();
+  const [courseType, setCourseType] = useState<CourseType>("COURSE");
+
+  const COURSE_TYPES: CourseType[] = ["COURSE", "SKILL_PATH"];
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const isLoading = createMutation.isPending;
+  const NONE_VALUE = "__none__";
+  const handleCreate = () => {
+    const result = createCourseSchema.safeParse({
+      courseTitle,
+      courseSubjectId,
+      languageId,
+      courseType,
+    });
+
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {};
+      result.error.issues.forEach((issue) => {
+        const key = issue.path[0] as string;
+        fieldErrors[key] = issue.message;
+      });
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setErrors({});
+
+    createMutation.mutate(
+      {
+        ...result.data,
+        languageId: result.data.languageId ?? null,
+        requestHash: crypto.randomUUID(),
+      },
+      {
+        onSuccess: () => {
+          setCourseTitle("");
+          setCourseSubjectId(0);
+          setLanguageId(undefined);
+          setCourseType("COURSE");
+          close();
+        },
+      },
+    );
+  };
+
+  return (
+    <LudoDialog
+      trigger={children}
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) close();
+      }}
+      className="max-w-3xl" // 👈 wider
+    >
+      <DialogTitle className="text-white font-bold text-xl">
+        Create Course
+      </DialogTitle>
+
+      <div className="grid grid-cols-2 gap-6 mt-6">
+        <LudoInput
+          containerClassName="col-span-2"
+          variant="dark"
+          title="Course Title"
+          value={courseTitle}
+          setValue={setCourseTitle}
+          error={errors.courseTitle}
+        />
+
+        <LudoSelect
+          variant="dark"
+          title="Subject"
+          value={courseSubjectId.toString()}
+          setValue={(v) => setCourseSubjectId(Number(v))}
+          error={errors.courseSubjectId}
+        >
+          {subjects.map((s) => (
+            <LudoSelectItem key={s.id} value={s.id.toString()}>
+              {s.name}
+            </LudoSelectItem>
+          ))}
+        </LudoSelect>
+
+        <LudoSelect
+          variant="dark"
+          title="Language (optional)"
+          value={languageId ? languageId.toString() : NONE_VALUE}
+          setValue={(v) =>
+            setLanguageId(v === NONE_VALUE ? undefined : Number(v))
+          }
+        >
+          <LudoSelectItem value={NONE_VALUE}>None</LudoSelectItem>
+
+          {languages.map((l) => (
+            <LudoSelectItem key={l.languageId} value={l.languageId.toString()}>
+              {l.name}
+            </LudoSelectItem>
+          ))}
+        </LudoSelect>
+
+        <LudoSelect
+          variant="dark"
+          title="Course Type"
+          value={courseType}
+          setValue={(v) => setCourseType(v as any)}
+          error={errors.courseType}
+        >
+          {COURSE_TYPES.map((type) => (
+            <LudoSelectItem key={type} value={type}>
+              {type}
+            </LudoSelectItem>
+          ))}
+        </LudoSelect>
+
+        <div className="col-span-2 pt-4">
+          <LudoButton
+            disabled={isLoading}
+            variant="alt"
+            onClick={handleCreate}
+            className="w-full flex justify-center"
+          >
+            Create Course
+            {isLoading && <Spinner className="ml-2 text-ludo-accent-muted" />}
+          </LudoButton>
+        </div>
+      </div>
+    </LudoDialog>
+  );
+}

--- a/apps/admin/src/features/CoursesHub/Pages/CoursesHubPage.tsx
+++ b/apps/admin/src/features/CoursesHub/Pages/CoursesHubPage.tsx
@@ -6,10 +6,14 @@ import { coursesHeroContent } from "../content";
 import { router } from "@/main";
 import { adminNavigation } from "@/constants/adminNavigation";
 import { ShadowLessButton } from "@ludocode/design-system/primitives/ShadowLessButton";
+import { useState } from "react";
+import { CreateCourseDialog } from "../Components/Dialog/CreateCourseDialog";
 
 export function CoursesHubPage() {
   const { data: courses } = useSuspenseQuery(qo.allCourses());
   const { data: subjects } = useSuspenseQuery(qo.allSubjects());
+
+  const [openCreateCourse, setOpenCreateCourse] = useState(false);
 
   return (
     <>
@@ -21,9 +25,18 @@ export function CoursesHubPage() {
               <LudoButton className="w-1/3 px-2" variant="alt">
                 Instructions
               </LudoButton>
-              <LudoButton variant="alt" className="w-1/3 px-2">
-                Create Course
-              </LudoButton>
+              <CreateCourseDialog
+                open={openCreateCourse}
+                close={() => setOpenCreateCourse(false)}
+              >
+                <LudoButton
+                  variant="alt"
+                  className="w-1/3 px-2"
+                  onClick={() => setOpenCreateCourse(true)}
+                >
+                  Create Course
+                </LudoButton>
+              </CreateCourseDialog>
             </div>
           </Hero>
           <div className="w-full grid grid-cols-12 gap-10">

--- a/apps/admin/src/hooks/Queries/Mutations/useCreateCourse.tsx
+++ b/apps/admin/src/hooks/Queries/Mutations/useCreateCourse.tsx
@@ -3,14 +3,13 @@ import { qk } from "@/hooks/Queries/Definitions/qk.ts";
 import type { LudoCourse } from "@ludocode/types/Catalog/LudoCourse.ts";
 import { mutations } from "@/hooks/Queries/Definitions/mutations";
 
-export function useCreateCourse(closeModal?: () => void) {
+export function useCreateCourse() {
   const qc = useQueryClient();
 
   return useMutation({
     ...mutations.createCourse(),
     onSuccess: (payload: LudoCourse[]) => {
       qc.setQueryData(qk.courses(), payload);
-      closeModal?.();
     },
   });
 }

--- a/packages/types/Builder/CreateCourseRequest.ts
+++ b/packages/types/Builder/CreateCourseRequest.ts
@@ -4,11 +4,6 @@ export type CreateCourseRequest = {
   courseTitle: string;
   requestHash: string;
   courseType: CourseType;
-  courseSubject: CreateCourseSubjectRequest;
-};
-
-export type CreateCourseSubjectRequest = {
-  slug: string;
-  name: string;
-  codeLanguageId: number;
+  courseSubjectId: number;
+  languageId: number | null;
 };

--- a/packages/types/Curriculum/CreateCourseSchema.ts
+++ b/packages/types/Curriculum/CreateCourseSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import type { CourseType } from "@ludocode/types";
+
+export const createCourseSchema = z.object({
+  courseTitle: z.string().min(1, "Title is required"),
+  courseSubjectId: z.number().min(1, "Subject is required"),
+  languageId: z.number().nullable().optional(),
+  courseType: z.union([z.literal("COURSE"), z.literal("SKILL_PATH")]),
+});

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -22,6 +22,7 @@ export * from "./Completion/SyncState";
 export * from "./Curriculum/CurriculumDraftSchema";
 export * from "./Curriculum/SubjectDraftSchema"
 export * from "./Curriculum/ChangeSubjectRequest"
+export * from "./Curriculum/CreateCourseSchema"
 
 // Exercise
 export * from "./Exercise/AnswerToken";


### PR DESCRIPTION
## Changes

- Added create course mutation that allows users to set the name, subject, type, and optionally the language.
- Calls `useCreateCourse()` mutation
- Uses form validation with `createCourseSchema` zod object

## Related Issues

- Closes #269 

## Screenshots
<img width="1292" height="823" alt="image" src="https://github.com/user-attachments/assets/d9296b3e-af98-4115-9030-76c5ee2f9f5f" />


## Keywords

Rabbit