### PR TITLE
style(chatbot): Remove borders & style markdown

### DIFF
--- a/packages/design-system/styles/theme/chatbot.css
+++ b/packages/design-system/styles/theme/chatbot.css
@@ -70,9 +70,14 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
+.chatbot-content div {
+  border: 1px solid #2a304f !important;
+}
+
 .chatbot-content pre {
   padding: 12px;
-  border: #22273e !important;
+  background: #22273e !important;
+  border: 1px solid #2a304f !important;
   border-radius: 0px !important;
   white-space: pre-wrap !important;
   word-break: break-word !important;
@@ -80,7 +85,7 @@
 
 .chatbot-content code {
   background: #2a2a3d !important;
-  border: #22273e !important;
+  border: 1px solid #2a304f !important;
   border-radius: 0px !important;
   font-family: "DMMono", monospace;
 }

--- a/packages/external/ai-elements/code-block.tsx
+++ b/packages/external/ai-elements/code-block.tsx
@@ -102,7 +102,7 @@ export const CodeBlock = ({
     <CodeBlockContext.Provider value={{ code }}>
       <div
         className={cn(
-          "group relative w-full  overflow-hidden rounded-md bg-background text-foreground",
+          "group relative w-full overflow-hidden rounded-md bg-background text-foreground",
           className
         )}
         {...props}


### PR DESCRIPTION
## Changes

- Added ludocode style border to `.code-block div {}` css class
- Made `.code-block pre {}` (the markdown blocks) to be `ludo-background`

## Related Issues

- Closes: #253 

## Screenshots

<img width="370" height="430" alt="image" src="https://github.com/user-attachments/assets/c16d4c31-b502-497d-9d4f-3720b8546518" />

## Keywords

Rabbit