### PR TITLE
fix(auth): Prevent duplicate requests

### DIFF
--- a/apps/web/src/hooks/Queries/Mutations/useFirebaseAuthEntry.tsx
+++ b/apps/web/src/hooks/Queries/Mutations/useFirebaseAuthEntry.tsx
@@ -21,19 +21,27 @@ function getFirebaseProvider(mode: AuthProviderMode) {
   }
 }
 
+import { useRef } from "react";
+
 export function useFirebaseAuthEntry() {
   const finalizeLogin = useFinalizeLogin();
+  const isRunningRef = useRef(false);
 
   return async (provider: AuthProviderMode) => {
-    try {
-      const firebaseProvider = getFirebaseProvider(provider);
+    if (isRunningRef.current) return;
 
+    try {
+      isRunningRef.current = true;
+
+      const firebaseProvider = getFirebaseProvider(provider);
       const result = await signInWithPopup(auth, firebaseProvider);
       const idToken = await result.user.getIdToken();
 
       await finalizeLogin(idToken);
     } catch (err) {
       handleFirebaseAuthError(err as FirebaseError);
+    } finally {
+      isRunningRef.current = false;
     }
   };
 }

--- a/apps/web/src/hooks/Queries/Mutations/useFirebaseEmailAuth.tsx
+++ b/apps/web/src/hooks/Queries/Mutations/useFirebaseEmailAuth.tsx
@@ -8,14 +8,21 @@ import { handleFirebaseAuthError } from "../../Error/handleFirebaseAuthError";
 import type { FirebaseError } from "firebase/app";
 import validator from "validator";
 import { errorToast } from "@ludocode/design-system/primitives/toast";
+import { useRef } from "react";
 
 export type EmailLoginMode = "REGISTER" | "LOGIN";
 
+
 export function useFirebaseEmailAuth() {
   const finalizeLogin = useFinalizeLogin();
+  const isRunningRef = useRef(false);
 
   return async (email: string, password: string, mode: EmailLoginMode) => {
+    if (isRunningRef.current) return; // prevent double submit
+
     try {
+      isRunningRef.current = true;
+
       if (!validator.isEmail(email)) {
         errorToast("Please enter a valid email address.");
         return;
@@ -29,9 +36,9 @@ export function useFirebaseEmailAuth() {
       const idToken = await result.user.getIdToken();
       await finalizeLogin(idToken);
     } catch (err) {
-      console.error(err);
-
       handleFirebaseAuthError(err as FirebaseError, mode);
+    } finally {
+      isRunningRef.current = false;
     }
   };
 }


### PR DESCRIPTION
## Changes

- Added running ref to email & provider auth hooks to prevent duplicate submissions
- Also fixes error toasts popping up from the second submission failing

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Firebase authentication reliability by preventing multiple concurrent login submissions, ensuring authentication requests are properly handled and preventing unexpected behavior from simultaneous sign-in attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->