### PR TITLE
refactor(preferences): Switch preferences update from bulk request to per-key toggles

### DIFF
--- a/apps/web/src/features/user/settings/AccountSettingsPage.tsx
+++ b/apps/web/src/features/user/settings/AccountSettingsPage.tsx
@@ -2,15 +2,9 @@ import { qo } from "@/queries/definitions/queries.ts";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FeatureToggleGroup } from "./components/FeatureToggleCard.tsx";
 import { ProfileCardContainer } from "@/features/user/components/ProfileCardContainer.tsx";
-import { LudoButton } from "@ludocode/design-system/primitives/ludo-button.tsx";
 import { AICreditBalanceCard } from "../../ai/components/AICreditBalanceCard.tsx";
 import { Avatar } from "@ludocode/design-system/primitives/avatar.tsx";
 import { getUserAvatar } from "@/constants/avatars/avatars.ts";
-import { router } from "@/main.tsx";
-import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
-import { useState } from "react";
-import { useEditPreferences } from "@/queries/mutations/useEditPreferences.tsx";
-import type { TogglePreferencesRequest } from "@ludocode/types";
 import { parseToDate } from "@ludocode/util";
 import { SubscriptionStatusCard } from "../../subscription/shared/components/SubscriptionStatusCard.tsx";
 
@@ -30,27 +24,6 @@ export function AccountSettingsPage() {
   } = subscription;
   const { data: aiCredits } = useSuspenseQuery(qo.credits());
 
-  const [audioEnabled, setAudioEnabled] = useState(preferences.audioEnabled);
-  const [aiEnabled, setAiEnabled] = useState(preferences.aiEnabled);
-
-  const editPreferencesMutation = useEditPreferences();
-
-  const handleSubmission = () => {
-    if (editPreferencesMutation.isPending) return;
-    if (
-      audioEnabled == preferences.audioEnabled &&
-      aiEnabled == preferences.aiEnabled
-    ) {
-      router.navigate(ludoNavigation.hub.profile.toProfile(user.id));
-    } else {
-      const submission: TogglePreferencesRequest = {
-        aiEnabled: aiEnabled,
-        audioEnabled: audioEnabled,
-      };
-      editPreferencesMutation.mutate(submission);
-    }
-  };
-
   return (
     <div className="col-span-full lg:px-4 relative lg:col-span-6 flex flex-col gap-2 lg:gap-0 lg:items-center h-full min-h-0 justify-start min-w-0">
       <div className="w-full flex gap-4 py-6 items-center">
@@ -69,10 +42,8 @@ export function AccountSettingsPage() {
       <div className="w-full flex pb-6 flex-col gap-4">
         <ProfileCardContainer header="PREFERENCES">
           <FeatureToggleGroup
-            audioEnabled={audioEnabled}
-            setAudioEnabled={setAudioEnabled}
-            aiEnabled={aiEnabled}
-            setAiEnabled={setAiEnabled}
+            audioEnabled={preferences.audioEnabled}
+            aiEnabled={preferences.aiEnabled}
           />
         </ProfileCardContainer>
 
@@ -96,17 +67,6 @@ export function AccountSettingsPage() {
               currentPeriodEnd={currentPeriodEnd}
             />
           </ProfileCardContainer>
-        </div>
-
-        <div className="w-full items-center border-t-2 pt-4 border-t-ludo-border">
-          <LudoButton
-            isLoading={editPreferencesMutation.isPending}
-            onClick={() => handleSubmission()}
-            variant="alt"
-            className="rounded-lg"
-          >
-            Save & Exit
-          </LudoButton>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/user/settings/components/FeatureToggleCard.tsx
+++ b/apps/web/src/features/user/settings/components/FeatureToggleCard.tsx
@@ -1,29 +1,33 @@
 import { BotIcon, Volume2Icon } from "lucide-react";
 import { StatsCard } from "../../../stats/components/StatsCard.tsx";
+import { useEditPreferences } from "@/queries/mutations/useEditPreferences.tsx";
 
 type FeatureToggleGroupProps = {
   audioEnabled: boolean;
-  setAudioEnabled: (value: boolean) => void;
   aiEnabled: boolean;
-  setAiEnabled: (value: boolean) => void;
 };
 
 export function FeatureToggleGroup({
   audioEnabled,
-  setAudioEnabled,
   aiEnabled,
-  setAiEnabled,
 }: FeatureToggleGroupProps) {
+  const mutation = useEditPreferences();
+
+  const handleToggle = (key: "AUDIO" | "AI", currentValue: boolean) => {
+    if (mutation.isPending) return;
+    mutation.mutate({ key, value: !currentValue });
+  };
+
   return (
     <div className="w-full flex justify-between gap-4">
       <StatsCard
-        onClick={() => setAudioEnabled(!audioEnabled)}
+        onClick={() => handleToggle("AUDIO", audioEnabled)}
         text={`Audio: ${audioEnabled ? "ON" : "OFF"}`}
       >
         <Volume2Icon className="h-6 text-ludo-white-bright" />
       </StatsCard>
       <StatsCard
-        onClick={() => setAiEnabled(!aiEnabled)}
+        onClick={() => handleToggle("AI", aiEnabled)}
         text={`AI: ${aiEnabled ? "ON" : "OFF"}`}
       >
         <BotIcon className="h-6 text-ludo-white-bright" />

--- a/apps/web/src/queries/mutations/useEditPreferences.tsx
+++ b/apps/web/src/queries/mutations/useEditPreferences.tsx
@@ -1,19 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { mutations } from "@/queries/definitions/mutations.ts";
 import { qk } from "@/queries/definitions/qk.ts";
-import { router } from "@/main.tsx";
-import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
 
 export function useEditPreferences() {
+  const qc = useQueryClient();
 
-    const qc = useQueryClient()
-
-    return useMutation({
-        ...mutations.editPreferences(),
-        onSuccess: (payload) => {
-            qc.setQueryData(qk.preferences(), payload)
-            router.navigate(ludoNavigation.hub.profile.toProfile(payload.userId))
-        }
-    })
-
+  return useMutation({
+    ...mutations.editPreferences(),
+    onSuccess: (payload) => {
+      qc.setQueryData(qk.preferences(), payload);
+    },
+  });
 }

--- a/packages/types/Preferences/TogglePreferencesRequest.ts
+++ b/packages/types/Preferences/TogglePreferencesRequest.ts
@@ -1,0 +1,6 @@
+export type TogglePreferencesRequest = {
+    value: boolean;
+    key: PreferenceRequestKey
+}
+
+export type PreferenceRequestKey = "AI" | "AUDIO"

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -57,6 +57,7 @@ export * from "./Project/LanguageMetadata";
 
 // Preferences
 export * from "./Preferences/LudoCareer"
+export * from "./Preferences/TogglePreferencesRequest"
 
 // Static
 export * from "./Static/DevInfoContent";
@@ -79,7 +80,6 @@ export * from "./User/UserPreferences";
 export * from "./User/UserStreak";
 export * from "./User/AvatarInfo";
 export * from "./User/EditProfileRequest";
-export * from "./User/TogglePreferencesRequest";
 
 // Zod
 export * from "./Zod/OnboardingSchema/OnboardingSnapSchema";


### PR DESCRIPTION
## Changes

- Removed Save & Exit button from account settings page
- Updating preferences now happens directly with the toggle buttons without needing confirmation
- Updated the `useEditPreferences()` mutation to use the new `PreferenceRequestKey` to represent the toggled feature

## Keywords

Rabbit