### PR TITLE
fix(ludo-mdx): Update app.css imports to get ludo color tokens

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,5 +1,6 @@
 @source "../../../packages/design-system/**/*.{ts,tsx,js,jsx}";
 @source "../../../packages/external/**/*.{ts,tsx,js,jsx}";
+@source "../../../packages/ludo-mdx/**/*.{ts,tsx,js,jsx,md,mdx}";
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "@ludocode/design-system/styles/components/ludo.css";

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -22,7 +22,9 @@
       "@ludocode/design-system": ["packages/design-system"],
       "@ludocode/design-system/*": ["packages/design-system/*"],
       "@ludocode/hooks": ["packages/hooks"],
-      "@ludocode/hooks/*": ["packages/hooks/*"]
+      "@ludocode/hooks/*": ["packages/hooks/*"],
+      "@ludocode/ludo-mdx": ["packages/ludo-mdx"],
+      "@ludocode/ludo-mdx/*": ["packages/ludo-mdx/*"]
     },
 
     /* Bundler mode */

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         __dirname,
         "../../packages/design-system",
       ),
+      "@ludocode/ludo-mdx": path.resolve(__dirname, "../../packages/ludo-mdx"),
       "@ludocode/hooks": path.resolve(__dirname, "../../packages/hooks"),
     },
   },


### PR DESCRIPTION
## Changes

- Added ludo-mdx to the apps tsconfig.app.json and vite.config.js
- Added ludo-mdx source to web apps App.css file

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to enable module resolution for the ludo-mdx package across the build system and TypeScript compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->