### PR TITLE
feat(profile): Add interaction to user stats cards

### DIFF
--- a/apps/web/src/features/stats/components/StatsCard.tsx
+++ b/apps/web/src/features/stats/components/StatsCard.tsx
@@ -10,7 +10,7 @@ type StatsCardProps = {
 
 export function StatsCard({ score, text, children, onClick }: StatsCardProps) {
   return (
-    <div className="w-full flex">
+
       <LudoButton
         onClick={() => onClick?.()}
         className="flex items-start px-4 py-3 h-auto gap-1.5 flex-col"
@@ -27,6 +27,5 @@ export function StatsCard({ score, text, children, onClick }: StatsCardProps) {
           {text}
         </p>
       </LudoButton>
-    </div>
   );
 }

--- a/apps/web/src/features/stats/components/UserStatsGroup.tsx
+++ b/apps/web/src/features/stats/components/UserStatsGroup.tsx
@@ -2,20 +2,36 @@ import { FireIcon } from "@heroicons/react/24/solid";
 import { StatsCard } from "./StatsCard.tsx";
 import { CommitIcon } from "@ludocode/design-system/primitives/custom-icon.tsx";
 import { useStatsContext } from "@/features/stats/context/StatsContext.tsx";
+import { CoinsDialog } from "./coins/CoinsDialog.tsx";
+import { StreakStatsDialog } from "./streak/StreakStatsDialog.tsx";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { qo } from "@/queries/definitions/queries.ts";
 
 export function UserStatsGroup() {
   const statsContext = useStatsContext();
+  const { data: pastWeekStreak } = useSuspenseQuery(qo.streakPastWeek());
   const { coins, userStreak } = statsContext;
   const { current } = userStreak;
 
   return (
     <div className="w-full flex justify-between gap-4">
-      <StatsCard text="Day Streak" score={current}>
-        <FireIcon className="h-6 text-orange-400" />
-      </StatsCard>
-      <StatsCard text="Commits" score={coins}>
-        <CommitIcon className="h-6 text-pythonYellow" />
-      </StatsCard>
+      <StreakStatsDialog
+        streak={userStreak}
+        pastWeekStreak={pastWeekStreak}
+      >
+        <div className="w-full flex">
+          <StatsCard text="Day Streak" score={current}>
+            <FireIcon className="h-6 text-orange-400" />
+          </StatsCard>
+        </div>
+      </StreakStatsDialog>
+      <CoinsDialog coins={coins}>
+        <div className="w-full flex">
+          <StatsCard text="Commits" score={coins}>
+            <CommitIcon className="h-6 text-pythonYellow" />
+          </StatsCard>
+        </div>
+      </CoinsDialog>
     </div>
   );
 }

--- a/apps/web/src/features/stats/components/coins/CoinsDialog.tsx
+++ b/apps/web/src/features/stats/components/coins/CoinsDialog.tsx
@@ -7,13 +7,13 @@ import {
 import { CommitIcon } from "@ludocode/design-system/primitives/custom-icon.tsx";
 import type { ReactNode } from "react";
 
-type CoinsDialogProps = { children: ReactNode; coins: number };
+type CoinsDialogProps = { children: ReactNode; coins: number; asChild?: boolean };
 
-export function CoinsDialog({ children, coins }: CoinsDialogProps) {
+export function CoinsDialog({ children, coins, asChild = true }: CoinsDialogProps) {
   return (
     <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogWrapper className="max-w-sm">
+      <DialogTrigger asChild={asChild}>{children}</DialogTrigger>
+      <DialogWrapper>
         <div className="flex flex-col items-center gap-4 py-2">
           <div className="w-14 h-14 rounded-full bg-white/15 flex items-center justify-center">
             <CommitIcon className="h-7 w-7 text-ludo-white-bright" />

--- a/apps/web/src/features/stats/components/streak/StreakStatsDialog.tsx
+++ b/apps/web/src/features/stats/components/streak/StreakStatsDialog.tsx
@@ -15,20 +15,22 @@ import { FireIcon } from "@heroicons/react/24/solid";
 type StreakStatsDialogProps = {
   children: ReactNode;
   streak: UserStreak;
+  asChild?: boolean;
   pastWeekStreak: DailyGoalMet[];
 };
 
 export function StreakStatsDialog({
   children,
   streak,
+  asChild = true,
   pastWeekStreak,
 }: StreakStatsDialogProps) {
   const { current, best } = streak;
 
   return (
     <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogWrapper className="max-w-sm">
+      <DialogTrigger asChild={asChild}>{children}</DialogTrigger>
+      <DialogWrapper>
         <div className="flex flex-col items-center gap-4 py-2">
           <div className="w-14 h-14 rounded-full bg-orange-400/15 flex items-center justify-center">
             <FireIcon className="h-7 w-7 text-orange-400" />

--- a/apps/web/src/features/stats/components/streak/WeeklyStreakGroup.tsx
+++ b/apps/web/src/features/stats/components/streak/WeeklyStreakGroup.tsx
@@ -38,7 +38,7 @@ export function WeeklyStreakGroup({
           <div key={index} className="flex flex-col items-center gap-1.5">
             <div
               className={cn(
-                "rounded-lg h-9 w-9 flex items-center justify-center transition-colors",
+                "rounded-sm lg:rounded-lg h-6 w-6 lg:h-9 lg:w-9 flex items-center justify-center transition-colors",
                 day.met ? "bg-orange-400/15" : "bg-white/5",
               )}
             >


### PR DESCRIPTION
## Changes

- Wrapped the streak & coins `StatsCard` in a `StreakStatsDialog` & `CoinsDialog` respectively

## Related Issues

- Closes #207 

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive dialogs for detailed streak statistics and coin information displays
  * Integrated past week streak data to provide additional streak insights

* **Style**
  * Improved responsive design for the weekly streak calendar with adaptive sizing and corner rounding for better mobile and desktop viewing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->