### PR TITLE
feat(preferences): Add audio toggle in lesson header

### DIFF
--- a/apps/web/src/features/lesson/components/AudioToggleIcon.tsx
+++ b/apps/web/src/features/lesson/components/AudioToggleIcon.tsx
@@ -1,0 +1,26 @@
+import { qo } from "@/queries/definitions/queries";
+import { useEditPreferences } from "@/queries/mutations/useEditPreferences";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { VolumeIcon, VolumeOffIcon } from "lucide-react";
+
+export function AudioToggleIcon() {
+  const { data: preferences } = useSuspenseQuery(qo.preferences());
+  const audioEnabled = preferences.audioEnabled
+
+  const mutation = useEditPreferences();
+
+  const handleToggle = () => {
+    if (mutation.isPending) return;
+    mutation.mutate({ key: "AUDIO", value: !audioEnabled });
+  };
+
+  return (
+    <div className="text-ludo-white-bright">
+      {audioEnabled ? (
+        <VolumeIcon className="hover:cursor-pointer w-5 h-5" strokeWidth={1} onClick={() => handleToggle()} />
+      ) : (
+        <VolumeOffIcon className="w-5 h-5 hover:cursor-pointer" onClick={() => handleToggle()} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/lesson/zones/LessonHeader.tsx
+++ b/apps/web/src/features/lesson/zones/LessonHeader.tsx
@@ -2,6 +2,8 @@ import { Progress } from "@ludocode/external/ui/progress.tsx";
 import { LeaveUnsavedDialog } from "@ludocode/design-system/templates/dialog/leave-unsaved-dialog.tsx";
 import { IconButton } from "@ludocode/design-system/primitives/icon-button.tsx";
 import { LudoHeader } from "@ludocode/design-system/zones/ludo-header.tsx";
+import { SpeakerIcon, VolumeIcon } from "lucide-react";
+import { AudioToggleIcon } from "../components/AudioToggleIcon";
 
 type LessonHeaderProps = {
   total: number;
@@ -14,7 +16,7 @@ export function LessonHeader({ total, onExit, position }: LessonHeaderProps) {
 
   return (
     <LudoHeader.Shell className="px-6" device="Both">
-      <div className="col-start-1 col-end-2 flex items-center h-full">
+      <div className="col-span-3 flex items-center h-full">
         {onExit && (
           <LeaveUnsavedDialog
             title="Are you sure you want to exit?"
@@ -26,11 +28,14 @@ export function LessonHeader({ total, onExit, position }: LessonHeaderProps) {
           </LeaveUnsavedDialog>
         )}
       </div>
-      <div className="flex items-center justify-center col-start-3 col-end-11 lg:col-start-4 lg:col-end-10">
+      <div className="flex items-center justify-center col-start-3 col-end-11 lg:col-span-6">
         <Progress
           className="border-ludo-accent-muted h-3"
           value={(completed / total) * 100}
         />
+      </div>
+      <div className="lg:col-span-3 flex items-center justify-end">
+        <AudioToggleIcon/>
       </div>
     </LudoHeader.Shell>
   );

--- a/apps/web/src/sound/soundManager.ts
+++ b/apps/web/src/sound/soundManager.ts
@@ -2,15 +2,15 @@ import { Howl } from "howler";
 
 const sounds = {
   correct: new Howl({
-    src: ["/audio/SFX/checkout.mp3"],
-    volume: 0.4,
+    src: ["/audio/SFX/success.mp3"],
+    volume: 0.3,
     html5: true,
     onloaderror: (error) =>
       console.error("Failed to load correct sound:", error),
   }),
   wrong: new Howl({
     src: ["/audio/SFX/wrong.mp3"],
-    volume: 0.4,
+    volume: 0.3,
     html5: true,
     onloaderror: (error) =>
       console.error("Failed to load wrong sound:", error),


### PR DESCRIPTION
## Changes

- Added an audio toggle button on the right side of the lesson header
  - Uses same `useEditPreferences()` mutation as on the account page

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio toggle control in the lesson header, allowing users to quickly switch audio on or off during lessons.

* **Bug Fixes**
  * Corrected audio files and adjusted volume levels for lesson sounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->