### PR TITLE
feat(courses): Add delete course to admin

### DIFF
--- a/apps/admin/src/features/courses-hub/components/CourseCard.tsx
+++ b/apps/admin/src/features/courses-hub/components/CourseCard.tsx
@@ -1,16 +1,18 @@
 import { adminNavigation } from "@/constants/adminNavigation.tsx";
 import { router } from "@/main.tsx";
 import type { LudoCourse } from "@ludocode/types";
+import { DeleteCourseButton } from "./DeleteCourseButton";
 
-type CourseCardProps = { course: LudoCourse };
+type CourseCardProps = { course: LudoCourse; coursesLength: number };
 
-export function CourseCard({ course }: CourseCardProps) {
+export function CourseCard({ course, coursesLength }: CourseCardProps) {
   return (
     <div
       key={course.id}
-      onClick={() =>
-        router.navigate(adminNavigation.curriculum.toCourse(course.id))
-      }
+      onClick={(e) => {
+        if (e.currentTarget !== e.target) return;
+        router.navigate(adminNavigation.curriculum.toCourse(course.id));
+      }}
       className="
                   bg-ludo-surface
                   hover:bg-ludo-surface/70
@@ -34,13 +36,16 @@ export function CourseCard({ course }: CourseCardProps) {
         </span>
       </div>
 
-      <div className="flex gap-6 text-sm text-ludo-white">
+      <div className="flex justify-between gap-6 text-sm text-ludo-white">
         <div>
           <span className="opacity-60">Language</span>
           <p className="text-ludo-white-bright font-medium">
             {course.language?.name ?? "—"}
           </p>
         </div>
+        {coursesLength > 1 && (
+          <DeleteCourseButton courseId={course.id} courseName={course.title} />
+        )}
       </div>
     </div>
   );

--- a/apps/admin/src/features/courses-hub/components/CreateCourseDialog.tsx
+++ b/apps/admin/src/features/courses-hub/components/CreateCourseDialog.tsx
@@ -77,7 +77,7 @@ export function CreateCourseDialog({ open, close, children }: Props) {
       onOpenChange={(next) => {
         if (!next) close();
       }}
-      className="max-w-3xl" // 👈 wider
+      className="max-w-3xl"
     >
       <DialogTitle className="text-ludo-white-bright font-bold text-xl">
         Create Course

--- a/apps/admin/src/features/courses-hub/components/DeleteCourseButton.tsx
+++ b/apps/admin/src/features/courses-hub/components/DeleteCourseButton.tsx
@@ -1,0 +1,41 @@
+import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog";
+import { TrashIcon } from "lucide-react";
+import { useDeleteCourse } from "../hooks/useDeleteCourse";
+
+type DeleteCourseButtonProps = { courseId: string; courseName: string };
+
+export function DeleteCourseButton({
+  courseId,
+  courseName,
+}: DeleteCourseButtonProps) {
+
+  const deleteCourseMutation = useDeleteCourse({
+    courseId: courseId,
+  });
+
+  const handleDeleteCourse = () => {
+    if (deleteCourseMutation.isPending) return;
+    deleteCourseMutation.mutate();
+  };
+  return (
+    <DeleteDialog
+      targetName={courseName}
+      triggerClassName="w-auto z-10"
+      asChild
+      destructiveConfirmation={{
+        confirmationText: `type ${courseName} to confirm`,
+        confirmationValue: courseName,
+      }}
+      onClick={() => handleDeleteCourse()}
+    >
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        className="flex items-end justify-end"
+      >
+        <TrashIcon className="h-6 w-6 text-ludo-danger rounded-full p-1 hover:cursor-pointer hover:bg-ludo-danger/40" />
+      </button>
+    </DeleteDialog>
+  );
+}

--- a/apps/admin/src/features/courses-hub/content.ts
+++ b/apps/admin/src/features/courses-hub/content.ts
@@ -1,6 +1,6 @@
 import type { HeroContentProps } from "@ludocode/design-system/zones/hero";
 
 export const coursesHeroContent: HeroContentProps = {
-  title: "courses",
+  title: "Editor",
   subtitle: "Here you are able to create and edit course and their content",
 };

--- a/apps/admin/src/features/courses-hub/hooks/useDeleteCourse.tsx
+++ b/apps/admin/src/features/courses-hub/hooks/useDeleteCourse.tsx
@@ -1,0 +1,19 @@
+import { mutations } from "@/queries/definitions/mutations";
+import { qk } from "@/queries/definitions/qk";
+import type { LudoCourse } from "@ludocode/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type Args = {
+  courseId: string;
+};
+
+export function useDeleteCourse({ courseId }: Args) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    ...mutations.deleteCourse(courseId),
+    onSuccess: async (payload: LudoCourse[]) => {
+      qc.setQueryData(qk.courses(), payload);
+    },
+  });
+}

--- a/apps/admin/src/features/courses-hub/zones/CoursesPane.tsx
+++ b/apps/admin/src/features/courses-hub/zones/CoursesPane.tsx
@@ -68,7 +68,7 @@ export function CoursesPane({ className, courses }: CoursesPaneProps) {
       )}
 
       {courses.map((course) => (
-        <CourseCard course={course} />
+        <CourseCard course={course} coursesLength={courses.length} />
       ))}
     </div>
   );

--- a/apps/admin/src/features/curriculum/navigator/preview/CurriculumPreview.tsx
+++ b/apps/admin/src/features/curriculum/navigator/preview/CurriculumPreview.tsx
@@ -9,6 +9,7 @@ import type { CurriculumDraft, CurriculumDraftLesson } from "@ludocode/types";
 import { ModulePreviewItem } from "./ModulePreviewItem.tsx";
 import { useRef } from "react";
 import { ShadowLessButton } from "@ludocode/design-system/primitives/shadowless-button.tsx";
+import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog.tsx";
 
 type CurriculumPreviewProps = {
   selectedLesson: CurriculumDraftLesson | null;
@@ -54,12 +55,17 @@ export function CurriculumPreview({
           />
           <ShadowLessButton
             variant="white"
+            className="w-auto text-sm h-auto px-4 py-1 rounded-sm"
             onClick={() => yamlInputRef.current?.click()}
             disabled={isUploadingYaml}
           >
-            {isUploadingYaml ? "Uploading…" : "Edit with YAML"}
+            {isUploadingYaml ? "Uploading…" : "Upload YAML"}
           </ShadowLessButton>
-          <ShadowLessButton variant="white" onClick={onDownload}>
+          <ShadowLessButton
+            className="w-auto text-sm h-auto px-4 py-1 rounded-sm"
+            variant="white"
+            onClick={onDownload}
+          >
             Download
           </ShadowLessButton>
           <LudoButton

--- a/apps/admin/src/features/language/components/DeleteLanguageButton.tsx
+++ b/apps/admin/src/features/language/components/DeleteLanguageButton.tsx
@@ -19,7 +19,7 @@ export function DeleteLanguageButton({
     languageId,
   });
 
-  const handleDeleteAccount = () => {
+  const handleDeleteLanguage = () => {
     if (deleteLanguageMutation.isPending) return;
     deleteLanguageMutation.mutate();
   };
@@ -39,7 +39,7 @@ export function DeleteLanguageButton({
       targetName="this language"
       description={description}
       destructiveConfirmation={confirmation}
-      onClick={() => handleDeleteAccount()}
+      onClick={() => handleDeleteLanguage()}
     >
       <LudoButton
         isLoading={deleteLanguageMutation.isPending}

--- a/apps/admin/src/queries/definitions/mutations.ts
+++ b/apps/admin/src/queries/definitions/mutations.ts
@@ -112,6 +112,16 @@ export const mutations = {
         ),
     });
   },
+  deleteCourse: (courseId: string) => {
+    return mutationOptions<LudoCourse[], Error, void>({
+      mutationKey: ["deleteCourse"],
+      mutationFn: () =>
+        ludoDelete<LudoCourse[]>(
+          adminApi.snapshots.byCourse(courseId),
+          true,
+        ),
+    });
+  },
   createLanguage: () => {
     return mutationOptions<LanguageMetadata[], Error, ModifyLanguageRequest>({
       mutationKey: ["createLanguage"],

--- a/packages/design-system/primitives/ludo-button.tsx
+++ b/packages/design-system/primitives/ludo-button.tsx
@@ -48,7 +48,7 @@ export const LudoButton = forwardRef<HTMLButtonElement, LudoButtonProps>(
       default: "shadow-ludo-surface",
       alt: "shadow-ludo-accent",
       white: "shadow-[0_7px_0_#D1D5DB]",
-      danger: "shadow-[0_7px_0_#C85A5A]",
+      danger: "shadow-ludo-danger",
     };
 
     const disabledShadowStyles: Record<LudoButtonVariant, string> = {

--- a/packages/design-system/templates/dialog/WarningDialog.tsx
+++ b/packages/design-system/templates/dialog/WarningDialog.tsx
@@ -3,6 +3,7 @@ import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
 import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
 import { DialogDescription, DialogTitle } from "@ludocode/external/ui/dialog";
 import { Input } from "@ludocode/external/ui/input";
+import { LudoInput } from "@ludocode/design-system/primitives/input";
 
 export type DestructiveActionConfirmation = {
   confirmationText: string;
@@ -16,6 +17,7 @@ type WarningDialogProps = {
   onClick: () => void;
   description?: string;
   triggerClassName?: string;
+  asChild?: boolean;
   destructiveConfirmation?: DestructiveActionConfirmation;
   children: ReactNode;
 };
@@ -25,6 +27,7 @@ export function WarningDialog({
   title,
   subtitle,
   description,
+  asChild = false,
   triggerClassName,
   onClick,
   buttonText,
@@ -42,26 +45,26 @@ export function WarningDialog({
 
   return (
     <LudoDialog
-      asChild={false}
+      asChild={asChild}
       trigger={children}
       triggerClassName={triggerClassName}
     >
       <DialogTitle className="text-ludo-white-bright">{title}</DialogTitle>
       {subtitle && (
-        <DialogDescription className="text-ludo-white-bright code font-bold">
+        <DialogDescription className="text-ludo-white code font-bold">
           {subtitle}
         </DialogDescription>
       )}
 
       {description && (
-        <DialogDescription className="text-ludo-white-bright code font-bold">
+        <DialogDescription className="text-ludo-white code font-bold">
           {description}
         </DialogDescription>
       )}
 
       {destructiveConfirmation && (
         <>
-          <DialogDescription className="text-ludo-white-bright code font-bold">
+          <DialogDescription className="text-ludo-white code font-bold">
             type
             <span className="text-ludo-danger">
               {" "}
@@ -69,9 +72,11 @@ export function WarningDialog({
             </span>
             to confirm
           </DialogDescription>
-          <Input
+          <LudoInput
             className="text-ludo-white"
-            onChange={(e) => setConfirmationValue(e.target.value)}
+            variant="dark"
+            setValue={setConfirmationValue}
+            value={confirmationValue}
           />
         </>
       )}

--- a/packages/design-system/templates/dialog/delete-dialog.tsx
+++ b/packages/design-system/templates/dialog/delete-dialog.tsx
@@ -10,6 +10,7 @@ type DeleteDialogProps = {
   description?: string;
   triggerClassName?: string;
   canDelete?: boolean;
+  asChild?: boolean;
   onClick: () => void;
   children: ReactNode;
 };
@@ -19,6 +20,7 @@ export function DeleteDialog({
   targetName,
   description,
   triggerClassName = "w-full",
+  asChild = false,
   destructiveConfirmation,
   children,
 }: DeleteDialogProps) {
@@ -27,6 +29,7 @@ export function DeleteDialog({
   return (
     <WarningDialog
       onClick={onClick}
+      asChild={asChild}
       title={title}
       triggerClassName={triggerClassName}
       description={description}


### PR DESCRIPTION
## Changes

- Added `useDeleteCourse()` mutation
- Added delete course icon with confirmation dialog in the courses panel in the admin app
- Added guard to prevent deleting the last course in the catalog

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course deletion functionality with a confirmation dialog that requires typing the course name to confirm.

* **Bug Fixes**
  * Improved course card click handling to prevent accidental navigation when interacting with card controls.

* **UI/UX Updates**
  * Changed hero section title from "courses" to "Editor."
  * Updated YAML button label from "Edit with YAML" to "Upload YAML."
  * Enhanced delete dialog input styling and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->