### PR TITLE
feat(courses): Add course visibility toggle & mutation

### DIFF
--- a/apps/admin/src/features/courses-hub/components/CourseCard.tsx
+++ b/apps/admin/src/features/courses-hub/components/CourseCard.tsx
@@ -1,11 +1,30 @@
 import { adminNavigation } from "@/constants/adminNavigation.tsx";
 import { router } from "@/main.tsx";
 import type { LudoCourse } from "@ludocode/types";
+import { Switch } from "@ludocode/external/ui/switch";
 import { DeleteCourseButton } from "./DeleteCourseButton";
+import { useToggleCourseVisibility } from "../hooks/useToggleCourseVisibility";
 
-type CourseCardProps = { course: LudoCourse; coursesLength: number };
+type CourseCardProps = {
+  course: LudoCourse;
+  coursesLength: number;
+  visibleCoursesCount: number;
+};
 
-export function CourseCard({ course, coursesLength }: CourseCardProps) {
+export function CourseCard({
+  course,
+  coursesLength,
+  visibleCoursesCount,
+}: CourseCardProps) {
+  const isVisible = course.isVisible !== false;
+  const isOnlyVisibleCourse = isVisible && visibleCoursesCount <= 1;
+  const toggleVisibility = useToggleCourseVisibility({ courseId: course.id });
+
+  const handleToggle = (checked: boolean) => {
+    if (toggleVisibility.isPending) return;
+    toggleVisibility.mutate({ value: checked });
+  };
+
   return (
     <div
       key={course.id}
@@ -43,9 +62,28 @@ export function CourseCard({ course, coursesLength }: CourseCardProps) {
             {course.language?.name ?? "—"}
           </p>
         </div>
-        {coursesLength > 1 && (
-          <DeleteCourseButton courseId={course.id} courseName={course.title} />
-        )}
+        <div className="flex items-end gap-3">
+          <div
+            className="flex items-center gap-2 z-10"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <span className="text-xs opacity-60">
+              {isVisible ? "Visible" : "Hidden"}
+            </span>
+            <Switch
+              checked={isVisible}
+              onCheckedChange={handleToggle}
+              disabled={isOnlyVisibleCourse || toggleVisibility.isPending}
+              className="data-[state=checked]:bg-ludo-accent data-[state=unchecked]:bg-ludo-surface-dim"
+            />
+          </div>
+          {coursesLength > 1 && (
+            <DeleteCourseButton
+              courseId={course.id}
+              courseName={course.title}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/admin/src/features/courses-hub/hooks/useToggleCourseVisibility.tsx
+++ b/apps/admin/src/features/courses-hub/hooks/useToggleCourseVisibility.tsx
@@ -1,0 +1,23 @@
+import { mutations } from "@/queries/definitions/mutations";
+import { qk } from "@/queries/definitions/qk";
+import type { LudoCourse } from "@ludocode/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export type VisibilityToggleRequest = {
+  value: boolean;
+};
+
+type Args = {
+  courseId: string;
+};
+
+export function useToggleCourseVisibility({courseId}: Args) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    ...mutations.toggleCourseVisibility(courseId),
+    onSuccess: (payload: LudoCourse[]) => {
+      qc.setQueryData(qk.courses(), payload);
+    },
+  });
+}

--- a/apps/admin/src/features/courses-hub/zones/CoursesPane.tsx
+++ b/apps/admin/src/features/courses-hub/zones/CoursesPane.tsx
@@ -68,7 +68,14 @@ export function CoursesPane({ className, courses }: CoursesPaneProps) {
       )}
 
       {courses.map((course) => (
-        <CourseCard course={course} coursesLength={courses.length} />
+        <CourseCard
+          key={course.id}
+          course={course}
+          coursesLength={courses.length}
+          visibleCoursesCount={
+            courses.filter((c) => c.isVisible !== false).length
+          }
+        />
       ))}
     </div>
   );

--- a/apps/admin/src/queries/definitions/mutations.ts
+++ b/apps/admin/src/queries/definitions/mutations.ts
@@ -13,6 +13,7 @@ import {
   type SubjectsDraftSnapshot,
 } from "@ludocode/types";
 import type { ChangeCourseIconRequest } from "@/features/curriculum/hooks/useChangeIcon";
+import type { VisibilityToggleRequest } from "@/features/courses-hub/hooks/useToggleCourseVisibility";
 
 export const mutations = {
   createCourse: () => {
@@ -116,10 +117,7 @@ export const mutations = {
     return mutationOptions<LudoCourse[], Error, void>({
       mutationKey: ["deleteCourse"],
       mutationFn: () =>
-        ludoDelete<LudoCourse[]>(
-          adminApi.snapshots.byCourse(courseId),
-          true,
-        ),
+        ludoDelete<LudoCourse[]>(adminApi.snapshots.byCourse(courseId), true),
     });
   },
   createLanguage: () => {
@@ -165,6 +163,17 @@ export const mutations = {
       mutationFn: (variables) =>
         ludoPut<LudoCourse[], ChangeLanguageRequest>(
           adminApi.snapshots.byCourseCurriculumLanguage(courseId),
+          variables,
+          true,
+        ),
+    });
+  },
+  toggleCourseVisibility: (courseId: string) => {
+    return mutationOptions<LudoCourse[], Error, VisibilityToggleRequest>({
+      mutationKey: ["toggleCourseVisibility"],
+      mutationFn: (variables) =>
+        ludoPut<LudoCourse[], VisibilityToggleRequest>(
+          adminApi.snapshots.byCourseVisibility(courseId),
           variables,
           true,
         ),

--- a/apps/admin/src/queries/definitions/queries.ts
+++ b/apps/admin/src/queries/definitions/queries.ts
@@ -85,7 +85,7 @@ export const qo = {
   allCourses: () =>
     queryOptions({
       queryKey: qk.courses(),
-      queryFn: () => ludoGet<LudoCourse[]>(adminApi.catalog.courses, true),
+      queryFn: () => ludoGet<LudoCourse[]>(adminApi.snapshots.courses, true),
       staleTime: 60_000,
     }),
 };

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -103,6 +103,9 @@ export function createApiPaths({
     snapshots: {
       base: `${ADMIN_BASE}/snapshots`,
       course: `${ADMIN_BASE}/snapshots/course`,
+      courses: `${ADMIN_BASE}/snapshots/courses`,
+      byCourseVisibility: (courseId: string) => 
+        `${ADMIN_BASE}/snapshots/${courseId}/visibility`,
       byCourseCurriculum: (courseId: string) =>
         `${ADMIN_BASE}/snapshots/curriculum/${courseId}`,
       byCourseCurriculumSubject: (courseId: string) =>

--- a/packages/external/ui/switch.tsx
+++ b/packages/external/ui/switch.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+
+import { cn } from "@ludocode/design-system/cn-utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80 focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background pointer-events-none block size-3.5 rounded-full ring-0 shadow-sm transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/packages/types/Catalog/LudoCourse.ts
+++ b/packages/types/Catalog/LudoCourse.ts
@@ -4,6 +4,7 @@ export type LudoCourse = {
   id: string;
   title: string;
   courseType: CourseType;
+  isVisible?: boolean;
   courseIcon: string;
   language?: LanguageMetadata;
   description: string;


### PR DESCRIPTION
## Changes

- Added a shadcn `switch` for toggling course visibility
- Added `useToggleCourseVisibility()` mutation and hook to toggle course visibility
- Added guard to prevent all courses from being invisible
- Switched the admin's `qo.allCourses()` queryFn to call the new admin backend courses endpoint instead of the user facing one

## Screenshots

<img width="855" height="532" alt="image" src="https://github.com/user-attachments/assets/ae387cd2-5139-49d8-9a96-4790f563b5d0" />

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added course visibility toggle in the admin courses panel, enabling administrators to show or hide individual courses
  * Toggle automatically disables when a course is the only visible one, preventing all courses from being hidden simultaneously

<!-- end of auto-generated comment: release notes by coderabbit.ai -->