### PR TITLE
feat(docs): Add roadmap mdx page & components

### DIFF
--- a/apps/web/src/constants/ludoNavigation.tsx
+++ b/apps/web/src/constants/ludoNavigation.tsx
@@ -82,8 +82,9 @@ export const ludoNavigation = {
         to: accountSettingsRoute.to,
         params: { userId },
       }),
-      toDocs: () => ({
+      toDocs: (slug?: string) => ({
         to: docsRoute.to,
+        search: slug ? { slug } : undefined,
       }),
     },
   },
@@ -92,7 +93,10 @@ export const ludoNavigation = {
     toResourcesRoute: () => ({ to: resourcesRootRoute.to }),
     toToS: () => ({ to: tosRoute.to }),
     toPrivacy: () => ({ to: privacyRoute.to }),
-    toDocs: () => ({ to: docsRoute.to }),
+    toDocs: (slug?: string) => ({
+      to: docsRoute.to,
+      search: slug ? { slug } : undefined,
+    }),
   },
 
   lesson: {

--- a/apps/web/src/features/hub/zones/HubDrawer.tsx
+++ b/apps/web/src/features/hub/zones/HubDrawer.tsx
@@ -11,6 +11,7 @@ import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
 import { router } from "@/main.tsx";
 import {
   LockIcon,
+  Map,
   NotebookText,
   Scroll,
   Settings,
@@ -91,15 +92,15 @@ export function HubDrawer({ trigger, user, plan }: ProfileDrawerProps) {
               onClick={() => router.navigate(ludoNavigation.resources.toDocs())}
             />
           </DrawerClose>
-          {/* <DrawerClose asChild>
+          <DrawerClose asChild>
             <NavItem
               icon={<Map className="h-5 w-5" />}
               label="Roadmap"
               onClick={() =>
-                router.navigate(ludoNavigation.hub.user.toSettings(user.id))
+                router.navigate(ludoNavigation.resources.toDocs("roadmap"))
               }
             />
-          </DrawerClose> */}
+          </DrawerClose>
           <DrawerClose asChild>
             <NavItem
               icon={<LockIcon className="h-5 w-5" />}

--- a/apps/web/src/features/webdocs/DocsPage.tsx
+++ b/apps/web/src/features/webdocs/DocsPage.tsx
@@ -6,6 +6,7 @@ import {
   DocsScrollSpyTOC,
   type TocHeading,
 } from "@ludocode/ludo-mdx/webdocs/DocsScrollSpyTOC.tsx";
+import { Route } from "@/routes/resources/docs/index.tsx";
 
 function extractHeadingsFromDOM(container: HTMLElement | null): TocHeading[] {
   if (!container) return [];
@@ -18,7 +19,11 @@ function extractHeadingsFromDOM(container: HTMLElement | null): TocHeading[] {
 }
 
 export function DocsPage() {
-  const [activeSlug, setActiveSlug] = useState(defaultSlug);
+  const { slug: initialSlug } = Route.useSearch();
+  const [activeSlug, setActiveSlug] = useState(
+    (initialSlug && findEntry(initialSlug) ? initialSlug : undefined) ??
+      defaultSlug,
+  );
   const [headings, setHeadings] = useState<TocHeading[]>([]);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/features/webdocs/content/roadmap.mdx
+++ b/apps/web/src/features/webdocs/content/roadmap.mdx
@@ -1,0 +1,78 @@
+---
+title: Roadmap
+slug: roadmap
+section: Project
+order: 5
+description: Planned features and the direction of Ludocode.
+---
+
+<br />
+Ludocode is open source. Suggestions, feedback, and contributions are welcome.
+The roadmap reflects current plans and may change based on community feedback
+and development priorities.
+<br />
+
+<Roadmap
+  milestones={[
+    {
+      date: "March 2026",
+      title: "Beta",
+      status: "shipped",
+      summary: "Initial public release of Ludocode.",
+      items: [
+        "Courses and lessons",
+        "Interactive exercises",
+        "Web code editor",
+        "Code runner",
+        "Progress tracking",
+      ],
+    },
+    {
+      date: "April 2026",
+      title: "Community & Leaderboards",
+      status: "in-progress",
+      summary: "Social features to encourage engagement.",
+      items: [
+        "Community hub for sharing projects",
+        "Public project pages",
+        "Global leaderboards",
+        "League-style ranking system",
+      ],
+    },
+    {
+      date: "April / May 2026",
+      title: "Interactive Projects & Guided Coding",
+      status: "planned",
+      summary: "Expanded exercise types.",
+      items: [
+        "Detailed guided coding exercises with the editor",
+        "Ability to run and iterate code directly in browser lessons",
+        "No hassle, shareable frontend projects hosted by Ludocode",
+      ],
+    },
+    {
+      date: "May 2026",
+      title: "Stable Release",
+      status: "planned",
+      summary: "First stable version of Ludocode.",
+      items: [
+        "Stability",
+        "Polish",
+        "Performance improvements",
+        "Documentation improvements",
+      ],
+    },
+    {
+      date: "June 2026",
+      title: "Terminal & Linux Exercises",
+      status: "planned",
+      summary: "More advanced learning environments.",
+      items: [
+        "Terminal-based exercises using Firecracker",
+        "Linux environment simulations",
+        "Shell scripting challenges",
+        "System-level programming tasks",
+      ],
+    },
+  ]}
+/>

--- a/apps/web/src/routes/resources/docs/index.tsx
+++ b/apps/web/src/routes/resources/docs/index.tsx
@@ -1,6 +1,11 @@
 import { DocsPage } from "@/features/webdocs/DocsPage.tsx";
 import { createFileRoute } from "@tanstack/react-router";
 
+type DocsSearch = { slug?: string };
+
 export const Route = createFileRoute("/resources/docs/")({
   component: DocsPage,
+  validateSearch: (search: Record<string, unknown>): DocsSearch => ({
+    slug: typeof search.slug === "string" ? search.slug : undefined,
+  }),
 });

--- a/packages/ludo-mdx/webdocs/DocsRoadmap.tsx
+++ b/packages/ludo-mdx/webdocs/DocsRoadmap.tsx
@@ -1,0 +1,145 @@
+import type { ReactNode } from "react";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type MilestoneStatus = "shipped" | "in-progress" | "planned";
+
+type RoadmapMilestone = {
+  date: string;
+  title: string;
+  status: MilestoneStatus;
+  summary: string;
+  items: string[];
+};
+
+type DocsRoadmapProps = {
+  milestones: RoadmapMilestone[];
+  children?: ReactNode;
+};
+
+// ─── Status config ──────────────────────────────────────────────────────────
+
+const statusConfig: Record<
+  MilestoneStatus,
+  { label: string; dot: string; badge: string; line: string }
+> = {
+  shipped: {
+    label: "Shipped",
+    dot: "bg-emerald-400",
+    badge: "bg-emerald-500/15 text-emerald-400 border-emerald-500/30",
+    line: "bg-emerald-500/25",
+  },
+  "in-progress": {
+    label: "In Progress",
+    dot: "bg-ludo-accent animate-pulse",
+    badge: "bg-ludo-accent/15 text-ludo-accent-muted border-ludo-accent/30",
+    line: "bg-ludo-accent/20",
+  },
+  planned: {
+    label: "Planned",
+    dot: "bg-ludo-white-dim/40",
+    badge: "bg-white/5 text-ludo-white-dim border-white/10",
+    line: "bg-white/8",
+  },
+};
+
+// ─── Milestone ──────────────────────────────────────────────────────────────
+
+function MilestoneNode({
+  milestone,
+  isLast,
+}: {
+  milestone: RoadmapMilestone;
+  isLast: boolean;
+}) {
+  const cfg = statusConfig[milestone.status];
+
+  return (
+    <div className="relative flex gap-4">
+      {/* Spine */}
+      <div className="relative flex flex-col items-center shrink-0 w-5">
+        <div className={`z-10 w-2.5 h-2.5 rounded-full mt-1.5 ${cfg.dot}`} />
+        {!isLast && (
+          <div
+            className={`w-px flex-1 mt-1 ${cfg.line}`}
+            style={{ minHeight: "1.5rem" }}
+          />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 pb-8 min-w-0">
+        <div className="flex flex-wrap items-center gap-2.5 mb-1">
+          <span className="text-[11px] font-bold uppercase tracking-widest text-ludo-white-dim/70">
+            {milestone.date}
+          </span>
+          <span
+            className={`text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full border ${cfg.badge}`}
+          >
+            {cfg.label}
+          </span>
+        </div>
+
+        <h3 className="text-sm font-bold text-ludo-white-bright mb-1 leading-snug">
+          {milestone.title}
+        </h3>
+        <p className="text-[13px] text-ludo-white leading-relaxed mb-2.5">
+          {milestone.summary}
+        </p>
+
+        {milestone.items.length > 0 && (
+          <ul className="space-y-1">
+            {milestone.items.map((item) => (
+              <li
+                key={item}
+                className="flex items-start gap-2 text-[13px] text-ludo-white-dim leading-relaxed"
+              >
+                <span className="mt-[7px] shrink-0 w-1 h-1 rounded-full bg-ludo-white-dim/40" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────────────────
+
+export function DocsRoadmap({ milestones, children }: DocsRoadmapProps) {
+  return (
+    <section className="mt-2 mb-6">
+      {/* Legend */}
+      <div className="flex flex-wrap gap-4 mb-5 text-[11px]">
+        {(["shipped", "in-progress", "planned"] as const).map((s) => (
+          <div key={s} className="flex items-center gap-1.5">
+            <span
+              className={`inline-block w-2 h-2 rounded-full ${statusConfig[s].dot}`}
+            />
+            <span className="text-ludo-white-dim font-medium uppercase tracking-wider">
+              {statusConfig[s].label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="h-px bg-gradient-to-r from-ludo-accent/30 to-transparent mb-6" />
+
+      {/* Timeline */}
+      <div className="relative">
+        {milestones.map((m, i) => (
+          <MilestoneNode
+            key={m.date + m.title}
+            milestone={m}
+            isLast={i === milestones.length - 1}
+          />
+        ))}
+      </div>
+
+      {children && (
+        <div className="mt-2 pl-9 text-sm text-ludo-white-dim">{children}</div>
+      )}
+    </section>
+  );
+}

--- a/packages/ludo-mdx/webdocs/MdxComponents.tsx
+++ b/packages/ludo-mdx/webdocs/MdxComponents.tsx
@@ -9,6 +9,7 @@ import type { MDXComponents } from "mdx/types";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { DocsTipCard } from "./DocsTipCard";
 import { DocsTabs } from "./DocsTabs";
+import { DocsRoadmap } from "./DocsRoadmap";
 
 // ─── Ludocode code theme ────────────────────────────────────────────────────
 
@@ -102,6 +103,7 @@ export const mdxComponents: MDXComponents = {
   Tip: DocsTipCard as ComponentType,
   Tabs: DocsTabs as ComponentType,
   CodeBlock: CodeBlock as ComponentType,
+  Roadmap: DocsRoadmap as ComponentType,
 
   // ── Heading overrides (IDs added by rehype-slug) ──
   h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => (


### PR DESCRIPTION
## Changes

- Added `DocsRoadmap.tsx` with roadmap related components such as milestone nodes
- Added a navigation to the roadmap slug in docs from the HubDrawer

## Screenshots

<img width="1210" height="821" alt="image" src="https://github.com/user-attachments/assets/768e1db9-5a9d-415d-8c4b-e53deab6dad1" />

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Roadmap feature now accessible in navigation, displaying project milestones with status, dates, and descriptions in an interactive timeline
  * Enhanced documentation navigation to support direct deep-linking to specific docs sections via URL parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->