### PR TITLE
refactor(courses): Switch to course status instead of visibility

### DIFF
--- a/apps/admin/src/features/courses-hub/components/CourseCard.tsx
+++ b/apps/admin/src/features/courses-hub/components/CourseCard.tsx
@@ -1,29 +1,18 @@
 import { adminNavigation } from "@/constants/adminNavigation.tsx";
 import { router } from "@/main.tsx";
-import type { LudoCourse } from "@ludocode/types";
-import { Switch } from "@ludocode/external/ui/switch";
+import type { CourseStatus, LudoCourse } from "@ludocode/types";
 import { DeleteCourseButton } from "./DeleteCourseButton";
-import { useToggleCourseVisibility } from "../hooks/useToggleCourseVisibility";
+import { useChangeCourseStatus } from "../hooks/useToggleCourseVisibility";
+import { CourseStatusBadge } from "@/features/curriculum/components/CourseStatusBadge";
+import { Archive, Globe } from "lucide-react";
 
 type CourseCardProps = {
   course: LudoCourse;
-  coursesLength: number;
-  visibleCoursesCount: number;
 };
 
-export function CourseCard({
-  course,
-  coursesLength,
-  visibleCoursesCount,
-}: CourseCardProps) {
-  const isVisible = course.isVisible !== false;
-  const isOnlyVisibleCourse = isVisible && visibleCoursesCount <= 1;
-  const toggleVisibility = useToggleCourseVisibility({ courseId: course.id });
-
-  const handleToggle = (checked: boolean) => {
-    if (toggleVisibility.isPending) return;
-    toggleVisibility.mutate({ value: checked });
-  };
+export function CourseCard({ course }: CourseCardProps) {
+  const courseStatus: CourseStatus = course.courseStatus ?? "DRAFT";
+  const changeCourseStatus = useChangeCourseStatus({ courseId: course.id });
 
   return (
     <div
@@ -50,9 +39,12 @@ export function CourseCard({
           {course.title}
         </h3>
 
-        <span className="text-xs text-ludo-white opacity-70">
-          {course.courseType}
-        </span>
+        <div className="flex items-center gap-2">
+          <CourseStatusBadge status={courseStatus} />
+          <span className="text-xs text-ludo-white opacity-70">
+            {course.courseType}
+          </span>
+        </div>
       </div>
 
       <div className="flex justify-between gap-6 text-sm text-ludo-white">
@@ -62,26 +54,52 @@ export function CourseCard({
             {course.language?.name ?? "—"}
           </p>
         </div>
-        <div className="flex items-end gap-3">
-          <div
-            className="flex items-center gap-2 z-10"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <span className="text-xs opacity-60">
-              {isVisible ? "Visible" : "Hidden"}
-            </span>
-            <Switch
-              checked={isVisible}
-              onCheckedChange={handleToggle}
-              disabled={isOnlyVisibleCourse || toggleVisibility.isPending}
-              className="data-[state=checked]:bg-ludo-accent data-[state=unchecked]:bg-ludo-surface-dim"
-            />
-          </div>
-          {coursesLength > 1 && (
-            <DeleteCourseButton
-              courseId={course.id}
-              courseName={course.title}
-            />
+        <div
+          className="flex items-end gap-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {courseStatus === "DRAFT" && (
+            <>
+              <button
+                type="button"
+                disabled={changeCourseStatus.isPending}
+                onClick={() =>
+                  changeCourseStatus.mutate({ value: "PUBLISHED" })
+                }
+                className="flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+              >
+                <Globe className="h-3.5 w-3.5" />
+                Publish
+              </button>
+              <DeleteCourseButton
+                courseId={course.id}
+                courseName={course.title}
+              />
+            </>
+          )}
+
+          {courseStatus === "PUBLISHED" && (
+            <button
+              type="button"
+              disabled={changeCourseStatus.isPending}
+              onClick={() => changeCourseStatus.mutate({ value: "ARCHIVED" })}
+              className="flex items-center gap-1.5 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-amber-500 disabled:opacity-50"
+            >
+              <Archive className="h-3.5 w-3.5" />
+              Archive
+            </button>
+          )}
+
+          {courseStatus === "ARCHIVED" && (
+            <button
+              type="button"
+              disabled={changeCourseStatus.isPending}
+              onClick={() => changeCourseStatus.mutate({ value: "PUBLISHED" })}
+              className="flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+            >
+              <Globe className="h-3.5 w-3.5" />
+              Publish
+            </button>
           )}
         </div>
       </div>

--- a/apps/admin/src/features/courses-hub/hooks/useToggleCourseVisibility.tsx
+++ b/apps/admin/src/features/courses-hub/hooks/useToggleCourseVisibility.tsx
@@ -1,21 +1,21 @@
 import { mutations } from "@/queries/definitions/mutations";
 import { qk } from "@/queries/definitions/qk";
-import type { LudoCourse } from "@ludocode/types";
+import type { CourseStatus, LudoCourse } from "@ludocode/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-export type VisibilityToggleRequest = {
-  value: boolean;
+export type ChangeCourseStatusRequest = {
+  value: CourseStatus;
 };
 
 type Args = {
   courseId: string;
 };
 
-export function useToggleCourseVisibility({courseId}: Args) {
+export function useChangeCourseStatus({ courseId }: Args) {
   const qc = useQueryClient();
 
   return useMutation({
-    ...mutations.toggleCourseVisibility(courseId),
+    ...mutations.changeCourseStatus(courseId),
     onSuccess: (payload: LudoCourse[]) => {
       qc.setQueryData(qk.courses(), payload);
     },

--- a/apps/admin/src/features/courses-hub/zones/CoursesPane.tsx
+++ b/apps/admin/src/features/courses-hub/zones/CoursesPane.tsx
@@ -68,14 +68,7 @@ export function CoursesPane({ className, courses }: CoursesPaneProps) {
       )}
 
       {courses.map((course) => (
-        <CourseCard
-          key={course.id}
-          course={course}
-          coursesLength={courses.length}
-          visibleCoursesCount={
-            courses.filter((c) => c.isVisible !== false).length
-          }
-        />
+        <CourseCard key={course.id} course={course} />
       ))}
     </div>
   );

--- a/apps/admin/src/features/curriculum/CurriculumPage.tsx
+++ b/apps/admin/src/features/curriculum/CurriculumPage.tsx
@@ -18,6 +18,12 @@ import { CurriculumBreadcrumbs } from "@/features/curriculum/components/Curricul
 import { router } from "@/main";
 import { adminNavigation } from "@/constants/adminNavigation";
 import { adminApi } from "@/constants/api/adminApi";
+import { useChangeCourseStatus } from "@/features/courses-hub/hooks/useToggleCourseVisibility";
+import { useDeleteCourse } from "@/features/courses-hub/hooks/useDeleteCourse";
+import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog";
+import { CourseStatusBadge } from "@/features/curriculum/components/CourseStatusBadge.tsx";
+import type { CourseStatus } from "@ludocode/types";
+import { Archive, Globe, TrashIcon } from "lucide-react";
 
 type CurriculumPageProps = {};
 
@@ -36,6 +42,12 @@ export function CurriculumPage({}: CurriculumPageProps) {
   const courseLanguage = courses.find((c) => c.id == courseId)?.language;
 
   const courseIcon = courses.find((c) => c.id === courseId)?.courseIcon;
+
+  const courseStatus: CourseStatus =
+    courses.find((c) => c.id === courseId)?.courseStatus ?? "DRAFT";
+
+  const changeCourseStatus = useChangeCourseStatus({ courseId });
+  const deleteCourseMutation = useDeleteCourse({ courseId });
 
   const [isEditing, setIsEditing] = useState(false);
 
@@ -127,9 +139,87 @@ export function CurriculumPage({}: CurriculumPageProps) {
               courseId={courseId}
               courseName={courseName}
             />
-            <h1 className="text-ludo-white-bright text-3xl font-bold">
-              {courseName}
-            </h1>
+            <div className="flex items-center gap-4">
+              <h1 className="text-ludo-white-bright text-3xl font-bold">
+                {courseName}
+              </h1>
+              <CourseStatusBadge status={courseStatus} />
+            </div>
+
+            <div className="flex items-center gap-3">
+              {courseStatus === "DRAFT" && (
+                <>
+                  <button
+                    type="button"
+                    disabled={changeCourseStatus.isPending}
+                    onClick={() =>
+                      changeCourseStatus.mutate({ value: "PUBLISHED" })
+                    }
+                    className="flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+                  >
+                    <Globe className="h-4 w-4" />
+                    Publish
+                  </button>
+                  <DeleteDialog
+                    targetName={courseName}
+                    triggerClassName="w-auto"
+                    asChild
+                    destructiveConfirmation={{
+                      confirmationText: `type ${courseName} to confirm`,
+                      confirmationValue: courseName,
+                    }}
+                    onClick={() => {
+                      if (!deleteCourseMutation.isPending) {
+                        deleteCourseMutation.mutate(undefined, {
+                          onSuccess: () => {
+                            router.navigate(
+                              adminNavigation.hub.courses.toCoursesHub(),
+                            );
+                          },
+                        });
+                      }
+                    }}
+                  >
+                    <button
+                      type="button"
+                      className="flex items-center gap-2 rounded-md bg-ludo-danger px-4 py-2 text-sm font-medium text-white transition hover:bg-ludo-danger/80"
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                      Delete
+                    </button>
+                  </DeleteDialog>
+                </>
+              )}
+
+              {courseStatus === "PUBLISHED" && (
+                <button
+                  type="button"
+                  disabled={changeCourseStatus.isPending}
+                  onClick={() =>
+                    changeCourseStatus.mutate({ value: "ARCHIVED" })
+                  }
+                  className="flex items-center gap-2 rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-500 disabled:opacity-50"
+                >
+                  <Archive className="h-4 w-4" />
+                  Archive
+                </button>
+              )}
+
+              {courseStatus === "ARCHIVED" && (
+                <button
+                  type="button"
+                  disabled={changeCourseStatus.isPending}
+                  onClick={() =>
+                    changeCourseStatus.mutate({ value: "PUBLISHED" })
+                  }
+                  className="flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+                >
+                  <Globe className="h-4 w-4" />
+                  Publish
+                </button>
+              )}
+            </div>
+
             <CurriculumHero
               courseLanguage={courseLanguage}
               courseId={courseId}

--- a/apps/admin/src/features/curriculum/components/CourseStatusBadge.tsx
+++ b/apps/admin/src/features/curriculum/components/CourseStatusBadge.tsx
@@ -1,0 +1,33 @@
+import type { CourseStatus } from "@ludocode/types";
+
+const statusConfig: Record<CourseStatus, { label: string; className: string }> =
+  {
+    DRAFT: {
+      label: "Draft",
+      className: "bg-slate-500/20 text-slate-300 border-slate-500/40",
+    },
+    PUBLISHED: {
+      label: "Published",
+      className: "bg-emerald-500/20 text-emerald-300 border-emerald-500/40",
+    },
+    ARCHIVED: {
+      label: "Archived",
+      className: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+    },
+  };
+
+type CourseStatusBadgeProps = {
+  status: CourseStatus;
+};
+
+export function CourseStatusBadge({ status }: CourseStatusBadgeProps) {
+  const config = statusConfig[status];
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${config.className}`}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/apps/admin/src/queries/definitions/mutations.ts
+++ b/apps/admin/src/queries/definitions/mutations.ts
@@ -13,7 +13,7 @@ import {
   type SubjectsDraftSnapshot,
 } from "@ludocode/types";
 import type { ChangeCourseIconRequest } from "@/features/curriculum/hooks/useChangeIcon";
-import type { VisibilityToggleRequest } from "@/features/courses-hub/hooks/useToggleCourseVisibility";
+import type { ChangeCourseStatusRequest } from "@/features/courses-hub/hooks/useToggleCourseVisibility";
 
 export const mutations = {
   createCourse: () => {
@@ -168,12 +168,12 @@ export const mutations = {
         ),
     });
   },
-  toggleCourseVisibility: (courseId: string) => {
-    return mutationOptions<LudoCourse[], Error, VisibilityToggleRequest>({
-      mutationKey: ["toggleCourseVisibility"],
+  changeCourseStatus: (courseId: string) => {
+    return mutationOptions<LudoCourse[], Error, ChangeCourseStatusRequest>({
+      mutationKey: ["changeCourseStatus"],
       mutationFn: (variables) =>
-        ludoPut<LudoCourse[], VisibilityToggleRequest>(
-          adminApi.snapshots.byCourseVisibility(courseId),
+        ludoPut<LudoCourse[], ChangeCourseStatusRequest>(
+          adminApi.snapshots.byCourseStatus(courseId),
           variables,
           true,
         ),

--- a/apps/web/src/features/course/hub/CoursePage.tsx
+++ b/apps/web/src/features/course/hub/CoursePage.tsx
@@ -5,7 +5,7 @@ import { Hero } from "@ludocode/design-system/zones/hero.tsx";
 import type { LudoCourse } from "@ludocode/types";
 
 export function CoursePage() {
-  const { allCourses } = useLoaderData({ from: "/_app/_hub/courses" });
+  const { availableCourses } = useLoaderData({ from: "/_app/_hub/courses" });
   const changeCourseMutation = useChangeCourse();
 
 
@@ -23,7 +23,7 @@ export function CoursePage() {
           subtitle="Browse all available courses and pick your next adventure"
         />
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-          {allCourses.map((course: LudoCourse) => (
+          {availableCourses.map((course: LudoCourse) => (
             <CourseCard
               key={course.id}
               onClick={() => handleSelectCourse(course.id)}

--- a/apps/web/src/features/user/profile/ProfilePage.tsx
+++ b/apps/web/src/features/user/profile/ProfilePage.tsx
@@ -5,7 +5,6 @@ import { ProfileCardContainer } from "@/features/user/components/ProfileCardCont
 import { UserStatsGroup } from "../../stats/components/UserStatsGroup.tsx";
 import { BadgeListCard } from "./components/BadgeCard.tsx";
 import { CourseCard } from "@/features/course/hub/components/CourseCard.tsx";
-import type { IconName } from "@ludocode/design-system/primitives/custom-icon.tsx";
 
 type ProfilePageProps = {};
 

--- a/apps/web/src/features/user/profile/components/BadgeCard.tsx
+++ b/apps/web/src/features/user/profile/components/BadgeCard.tsx
@@ -1,5 +1,8 @@
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button.tsx";
-import { AnimatedBadge, Badge } from "@ludocode/design-system/primitives/badge.tsx";
+import {
+  AnimatedBadge,
+  Badge,
+} from "@ludocode/design-system/primitives/badge.tsx";
 import type { CourseStats, LudoCourse } from "@ludocode/types";
 import { type IconName } from "@ludocode/design-system/primitives/custom-icon.tsx";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
@@ -15,29 +18,39 @@ export function BadgeListCard({
   allCourses,
   allCourseStats,
 }: BadgeCardListProps) {
-  const completedCourseIds = new Set(
-    allCourseStats
-      .filter((stat) => stat.completedLessons === stat.totalLessons)
-      .map((stat) => stat.id),
+  const statsMap = new Map(allCourseStats.map((s) => [s.id, s]));
+
+  const coursesWithStatus = allCourses.map((course) => {
+    const stats = statsMap.get(course.id);
+
+    const started = stats ? stats.completedLessons > 0 : false;
+    const completed = stats
+      ? stats.completedLessons === stats.totalLessons
+      : false;
+
+    return {
+      ...course,
+      stats,
+      started,
+      completed,
+    };
+  });
+
+  const visibleCourses = coursesWithStatus.filter(
+    (course) => course.courseStatus === "PUBLISHED" || course.started,
   );
 
-  const coursesWithStatus = allCourses.map((course) => ({
-    ...course,
-    completed: completedCourseIds.has(course.id),
-    stats: allCourseStats.find((s) => s.id === course.id),
-  }));
-
-  const earnedCount = coursesWithStatus.filter((c) => c.completed).length;
-
+  const earnedCount = visibleCourses.filter((c) => c.completed).length;
+  
   return (
     <div className="flex flex-col gap-3 w-full">
       <div className="flex items-center justify-between">
         <p className="text-xs text-ludo-white-dim">
-          {earnedCount} / {allCourses.length} earned
+          {earnedCount} / {visibleCourses.length} earned
         </p>
       </div>
       <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
-        {coursesWithStatus.map((course) => (
+        {visibleCourses.map((course) => (
           <div
             key={course.id}
             className={cn(

--- a/apps/web/src/layouts/onboarding/OnboardingLayout.tsx
+++ b/apps/web/src/layouts/onboarding/OnboardingLayout.tsx
@@ -23,6 +23,11 @@ export function OnboardingLayout() {
 
   const { data: currentUser } = useSuspenseQuery(qo.currentUser());
   const { data: courses } = useSuspenseQuery(qo.allCourses());
+
+  const activeCourses = courses.filter(
+    (course) => course.courseStatus === "PUBLISHED",
+  );
+
   const { data: careers } = useSuspenseQuery(qo.allCareers());
 
   const draft = useOnboardingDraftStore((s) => s.draft);
@@ -41,7 +46,7 @@ export function OnboardingLayout() {
 
   const contextValue: OnboardingContextType = {
     currentUser,
-    courses,
+    courses: activeCourses,
     careers,
     flow,
   };

--- a/apps/web/src/routes/_app/_hub/courses.tsx
+++ b/apps/web/src/routes/_app/_hub/courses.tsx
@@ -17,17 +17,20 @@ async function coursesLoader(queryClient: QueryClient) {
   const allCourses = await queryClient.ensureQueryData(qo.allCourses());
   const enrolled: string[] = await queryClient.ensureQueryData(qo.enrolled());
 
-  await Promise.all(
-    enrolled.map((enrolledId) =>
-      queryClient.ensureQueryData(qo.courseProgress(enrolledId)),
-    ),
+  const enrolledSet = new Set(enrolled);
+
+  const availableCourses = allCourses.filter(
+    (course) =>
+      course.courseStatus === "PUBLISHED" ||
+      (course.courseStatus === "ARCHIVED" && enrolledSet.has(course.id)),
   );
 
   await Promise.all(
-    enrolled.map((enrolledId) =>
-      queryClient.ensureQueryData(qo.courseStats(enrolledId)),
-    ),
+    enrolled.flatMap((id) => [
+      queryClient.ensureQueryData(qo.courseProgress(id)),
+      queryClient.ensureQueryData(qo.courseStats(id)),
+    ]),
   );
 
-  return { allCourses, enrolled, currentUser };
+  return { availableCourses, enrolled, currentUser };
 }

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -104,8 +104,8 @@ export function createApiPaths({
       base: `${ADMIN_BASE}/snapshots`,
       course: `${ADMIN_BASE}/snapshots/course`,
       courses: `${ADMIN_BASE}/snapshots/courses`,
-      byCourseVisibility: (courseId: string) => 
-        `${ADMIN_BASE}/snapshots/${courseId}/visibility`,
+      byCourseStatus: (courseId: string) =>
+        `${ADMIN_BASE}/snapshots/${courseId}/status`,
       byCourseCurriculum: (courseId: string) =>
         `${ADMIN_BASE}/snapshots/curriculum/${courseId}`,
       byCourseCurriculumSubject: (courseId: string) =>

--- a/packages/types/Catalog/LudoCourse.ts
+++ b/packages/types/Catalog/LudoCourse.ts
@@ -4,10 +4,12 @@ export type LudoCourse = {
   id: string;
   title: string;
   courseType: CourseType;
-  isVisible?: boolean;
+  courseStatus?: CourseStatus;
   courseIcon: string;
   language?: LanguageMetadata;
   description: string;
 };
 
 export type CourseType = "COURSE" | "SKILL_PATH";
+
+export type CourseStatus = "DRAFT" | "ARCHIVED" | "PUBLISHED"


### PR DESCRIPTION
## Changes

- Instead of toggling visibility for a course, admins can now only toggle between published and archived
- Only draft courses can be deleted. Once a course has been published, it can only be archived at most
- Learners who were enrolled in archived courses can still see and participate in them, but other learners can not see nor enroll in archived courses

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Course lifecycle management: Publish, archive, and delete courses with clear status-based action buttons
  * Status badges display current course state (Draft, Published, or Archived) in cards and headers
  * Improved course visibility: Display only published courses and enrolled archived courses

* **Refactor**
  * Simplified course card component configuration and updated API endpoints for status management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->