### PR TITLE
fix(audio): Stop howler audio when page is hidden

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import { Howler } from "howler";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./App.css";
@@ -9,6 +10,16 @@ import type { LessonSubmissionRequest } from "packages/types/Exercise/LessonSubm
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 const queryClient = new QueryClient();
+
+window.addEventListener("pagehide", () => {
+  Howler.stop();
+});
+
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    Howler.stop();
+  }
+});
 
 export const router = createRouter({
   routeTree,


### PR DESCRIPTION
## Changes

- Added pagehide and visibilitychange listeners in main.tsx to stop howlet if a user leaves the site

Otherwise on IOS at least the audio widget was showing on lock screen

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio playback now automatically stops when navigating away from the page or when the page is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->