### PR TITLE
feat(feedback): Add feedback dialog

### DIFF
--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { mutations } from "@/queries/definitions/mutations.ts";
+import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog.tsx";
+import {
+  DialogDescription,
+  DialogTitle,
+} from "@ludocode/external/ui/dialog.tsx";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button.tsx";
+import { Textarea } from "@ludocode/external/ui/textarea.tsx";
+import type { ReactNode } from "react";
+import type { FeedbackType } from "@ludocode/types";
+
+type FeedbackDialogProps = {
+  children: ReactNode;
+  entityId?: string;
+  feedbackType?: FeedbackType;
+};
+
+export function FeedbackDialog({
+  children,
+  entityId,
+  feedbackType = "GENERAL",
+}: FeedbackDialogProps) {
+  const [content, setContent] = useState("");
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const mutation = useMutation({
+    ...mutations.submitFeedback(),
+    onSuccess: () => {
+      setSubmitted(true);
+      setTimeout(() => {
+        setOpen(false);
+      }, 1500);
+    },
+  });
+
+  const handleSubmit = () => {
+    if (!content.trim() || mutation.isPending) return;
+    mutation.mutate({
+      content: content.trim(),
+      ...(entityId ? { entityId } : {}),
+      feedbackType: feedbackType,
+    });
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setTimeout(() => {
+        setContent("");
+        setSubmitted(false);
+      }, 300);
+    }
+  };
+
+  return (
+    <LudoDialog trigger={children} open={open} onOpenChange={handleOpenChange}>
+      {submitted ? (
+        <>
+          <DialogTitle className="text-ludo-white-bright">
+            Thank you!
+          </DialogTitle>
+          <DialogDescription className="text-ludo-white">
+            Your feedback has been submitted.
+          </DialogDescription>
+        </>
+      ) : (
+        <>
+          <DialogTitle className="text-ludo-white-bright mb-4">
+            {feedbackType == "EXERCISE"
+              ? "Issue with this exercise?"
+              : "Got feedback or ideas?"}
+          </DialogTitle>
+
+          <Textarea
+            className="min-h-24 bg-ludo-background text-ludo-white-bright border-ludo-border focus-visible:border-ludo-accent focus-visible:ring-ludo-accent/50 resize-none"
+            placeholder="Write your feedback here..."
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            maxLength={2000}
+          />
+
+          <LudoButton
+            className="w-full h-10"
+            variant="alt"
+            disabled={!content.trim() || mutation.isPending}
+            isLoading={mutation.isPending}
+            onClick={handleSubmit}
+          >
+            Submit
+          </LudoButton>
+
+          {mutation.isError && (
+            <p className="text-xs text-red-400">
+              Something went wrong. Please try again.
+            </p>
+          )}
+        </>
+      )}
+    </LudoDialog>
+  );
+}

--- a/apps/web/src/features/hub/zones/HubDrawer.tsx
+++ b/apps/web/src/features/hub/zones/HubDrawer.tsx
@@ -12,12 +12,14 @@ import { router } from "@/main.tsx";
 import {
   LockIcon,
   Map,
+  MessageSquarePlus,
   NotebookText,
   Scroll,
   Settings,
   User,
   X,
 } from "lucide-react";
+import { FeedbackDialog } from "@/features/feedback/FeedbackDialog.tsx";
 import type { ReactElement } from "react";
 import type { LudoUser, SubscriptionPlan } from "@ludocode/types";
 import { LogoutButton } from "@/features/auth/components/LogoutButton.tsx";
@@ -101,6 +103,13 @@ export function HubDrawer({ trigger, user, plan }: ProfileDrawerProps) {
               }
             />
           </DrawerClose>
+          <FeedbackDialog>
+            <NavItem
+              icon={<MessageSquarePlus className="h-5 w-5" />}
+              label="Submit Feedback"
+              onClick={() => {}}
+            />
+          </FeedbackDialog>
           <DrawerClose asChild>
             <NavItem
               icon={<LockIcon className="h-5 w-5" />}

--- a/apps/web/src/features/lesson/components/ExerciseFeedbackIcon.tsx
+++ b/apps/web/src/features/lesson/components/ExerciseFeedbackIcon.tsx
@@ -1,0 +1,19 @@
+import { FeedbackDialog } from "@/features/feedback/FeedbackDialog.tsx";
+import { useLessonContext } from "@/features/lesson/context/useLessonContext.tsx";
+import { Flag } from "lucide-react";
+
+export function ExerciseFeedbackIcon() {
+  const { currentExercise } = useLessonContext();
+
+  return (
+    <FeedbackDialog feedbackType={"EXERCISE"} entityId={currentExercise.id}>
+      <button
+        type="button"
+        aria-label="Report exercise feedback"
+        className="text-ludo-white hover:cursor-pointer"
+      >
+        <Flag className="w-5 h-5" strokeWidth={1} />
+      </button>
+    </FeedbackDialog>
+  );
+}

--- a/apps/web/src/features/lesson/zones/LessonHeader.tsx
+++ b/apps/web/src/features/lesson/zones/LessonHeader.tsx
@@ -3,6 +3,7 @@ import { LeaveUnsavedDialog } from "@ludocode/design-system/templates/dialog/lea
 import { IconButton } from "@ludocode/design-system/primitives/icon-button.tsx";
 import { LudoHeader } from "@ludocode/design-system/zones/ludo-header.tsx";
 import { AudioToggleIcon } from "../components/AudioToggleIcon";
+import { ExerciseFeedbackIcon } from "../components/ExerciseFeedbackIcon";
 
 type LessonHeaderProps = {
   total: number;
@@ -33,8 +34,9 @@ export function LessonHeader({ total, onExit, position }: LessonHeaderProps) {
           value={(completed / total) * 100}
         />
       </div>
-      <div className="col-span-2 lg:col-span-3 flex items-center justify-end">
-        <AudioToggleIcon/>
+      <div className="col-span-2 lg:col-span-3 flex items-center justify-end gap-3">
+        <ExerciseFeedbackIcon />
+        <AudioToggleIcon />
       </div>
     </LudoHeader.Shell>
   );

--- a/apps/web/src/queries/definitions/mutations.ts
+++ b/apps/web/src/queries/definitions/mutations.ts
@@ -25,6 +25,7 @@ import type {
   LudoUser,
   UserSubscription,
   ConfirmRequest,
+  FeedbackRequest,
 } from "@ludocode/types";
 
 export interface ChangeCourseVariables {
@@ -54,6 +55,22 @@ export const mutations = {
       mutationFn: (variables) =>
         ludoPost<UserSubscription, ConfirmRequest>(
           api.subscriptions.confirm,
+          variables,
+          true,
+        ),
+    });
+  },
+
+  submitFeedback: () => {
+    return mutationOptions<
+      void,
+      Error,
+      FeedbackRequest
+    >({
+      mutationKey: ["submitFeedback"],
+      mutationFn: (variables) =>
+        ludoPost<void, FeedbackRequest>(
+          api.feedback.base,
           variables,
           true,
         ),

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -124,6 +124,10 @@ export function createApiPaths({
       byAdminId: (subjectId: number) => `${ADMIN_BASE}/subjects/${subjectId}`,
     },
 
+    feedback: {
+      base: `${BASE}/feedback`
+    },
+
     subscriptions: {
       base: `${BASE}/subscription`,
       checkout: `${BASE}/subscription/checkout`,

--- a/packages/types/Feedback/FeedbackRequest.ts
+++ b/packages/types/Feedback/FeedbackRequest.ts
@@ -1,0 +1,7 @@
+export type FeedbackType = "GENERAL" | "EXERCISE" | "PROJECT"
+
+export type FeedbackRequest = {
+  content: string;
+  feedbackType: FeedbackType
+  entityId?: string;
+};

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -39,6 +39,9 @@ export * from "./Languages/ChangeLanguageRequest";
 export * from "./Onboarding/OnboardingCourse";
 export * from "./Onboarding/OnboardingResponse";
 
+// Feedback
+export * from "./Feedback/FeedbackRequest"
+
 // Piston
 export * from "./Piston/Runtimes";
 


### PR DESCRIPTION
## Changes

- Added a submit feedback dialog in the hub drawer and exercise page
- Added mutation for handling feedback submission
- Feedback can have a type like EXERCISE and associated entityId (so for EXERCISE its exerciseId, for PROJECT its projectId, etc)

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feedback submission feature accessible from the hub navigation menu.
  * Added in-context feedback reporting directly from exercises within lessons, allowing users to report issues with specific exercises.
  * Feedback dialog supports different feedback types with optional entity tracking for targeted feedback collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->