### PR TITLE
refactor(onboarding): Center content & tone down animations

### DIFF
--- a/apps/web/src/features/onboarding/components/WideOnboardingOption.tsx
+++ b/apps/web/src/features/onboarding/components/WideOnboardingOption.tsx
@@ -21,11 +21,11 @@ export function WideOnboardingOption({
       onClick={onClick}
       variant={isSelected ? "alt" : "default"}
       className={cn(
-        "p-6 min-h-30 flex flex-col items-center gap-2 justify-center rounded-2xl",
-        "transition-all border-2 duration-200",
+        "p-4 min-h-20 flex flex-col items-center gap-1.5 justify-center rounded-xl",
+        "transition-[transform] duration-100 transform-gpu will-change-transform touch-action-manipulation",
         isSelected
-          ? "border-transparent"
-          : "border-transparent hover:scale-[1.02]",
+          ? "border-ludo-accent/40"
+          : "border-transparent hover:border-ludo-border",
       )}
     >
       {children}

--- a/apps/web/src/features/onboarding/zone/OnboardingStageShell.tsx
+++ b/apps/web/src/features/onboarding/zone/OnboardingStageShell.tsx
@@ -14,10 +14,10 @@ export function OnboardingStageShell({
 }: OnboardingStageShellProps) {
   return (
     <motion.div
-      initial={{ opacity: 0, y: 16 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6, ease: "easeInOut" }}
-      className="flex flex-col items-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.8, ease: "easeInOut" }}
+      className="flex flex-col justify-center items-center w-full"
     >
       <h1 className="text-3xl text-center font-bold text-ludo-white-bright tracking-tight">
         {title}

--- a/apps/web/src/layouts/onboarding/OnboardingLayout.tsx
+++ b/apps/web/src/layouts/onboarding/OnboardingLayout.tsx
@@ -59,8 +59,8 @@ export function OnboardingLayout() {
       <MainGridWrapper gridRows="FULL">
         <OnboardingHeader total={total} position={current} />
         <MainContentWrapper>
-          <div className="relative grid col-span-full grid-cols-12">
-            <div className="col-start-2 col-end-12 lg:col-start-3 lg:col-end-11 py-10 min-w-0">
+          <div className="relative grid col-span-full grid-cols-12 h-full">
+            <div className="col-start-2 col-end-12 lg:col-start-3 lg:col-end-11 min-w-0 flex pb-20 items-center justify-center">
               <Step />
             </div>
           </div>


### PR DESCRIPTION
## Changes

- Onboarding steps are now centered on the screen rather than centered at the top
- Onboarding options no longer have a scale animation and instead use the `LudoButton` animation
- Animation now fades in from the same position without a fading up