### PR TITLE
chore: Update landing page content

### DIFF
--- a/apps/web/src/features/landing/components/LandingFeatures.tsx
+++ b/apps/web/src/features/landing/components/LandingFeatures.tsx
@@ -2,9 +2,8 @@ import { HeroIcon } from "@ludocode/design-system/primitives/hero-icon";
 import { LudoCard } from "@ludocode/design-system/primitives/ludo-card";
 import { landingPageFeatures } from "../content";
 
-type LandingFeaturesProps = {};
 
-export function LandingFeatures({}: LandingFeaturesProps) {
+export function LandingFeatures() {
   return (
     <section className="px-6 lg:px-18 py-20 lg:py-28 flex flex-col items-center gap-12 max-w-5xl mx-auto">
       <h2 className="text-2xl lg:text-4xl font-bold text-ludo-white-bright">

--- a/apps/web/src/features/landing/components/LandingHero.tsx
+++ b/apps/web/src/features/landing/components/LandingHero.tsx
@@ -7,11 +7,10 @@ export function LandingHero() {
   return (
     <section className="px-6 lg:px-18 py-16 lg:pt-32 lg:pb-24 flex flex-col items-center text-center gap-6 max-w-4xl mx-auto">
       <h1 className="text-4xl lg:text-6xl font-bold text-ludo-white-bright leading-tight">
-        Practice programming in small steps
+        Learn programming interactively
       </h1>
       <p className="text-base lg:text-lg text-ludo-white max-w-xl">
-        Ludocode is an open-source platform for learning programming through
-        small, interactive exercises.
+        Open-source platform for learning programming through approachable, interactive exercises.
       </p>
       <div className="flex gap-4 mt-4 h-10 w-full">
         <LudoButton

--- a/apps/web/src/features/landing/content.ts
+++ b/apps/web/src/features/landing/content.ts
@@ -4,7 +4,7 @@ export const landingPageFeatures: { icon: IconName; title: string; description: 
   {
     icon: "CodeBracketIcon",
     title: "Interactive Exercises",
-    description: "Practice programming with small, interactive lessons.",
+    description: "Practice programming with approachable, interactive lessons.",
   },
   {
     icon: "PlayIcon",


### PR DESCRIPTION
## Changes

- Changed landing hero from "Practice programming in small steps" to "Learn programming interactively".
- Changed landing hero subtitle from "Ludocode is an open-source platform for learning programming through small, interactive exercises." to "Open-source platform for learning programming through approachable, interactive exercises."
- Removed empty `LandingFeaturesProps` type.