### PR TITLE
chore(analytics): Allow disabling analytics via localStorage flag

### DIFF
--- a/apps/web/src/analytics/track.ts
+++ b/apps/web/src/analytics/track.ts
@@ -2,6 +2,7 @@ import { api } from "@/constants/api/api";
 import type { AnalyticsEvent } from "./events";
 
 export async function track(event: AnalyticsEvent) {
+  if (localStorage.getItem("disable_analytics") === "true") return;
   try {
     await fetch(api.analytics.base, {
       method: "POST",
@@ -11,6 +12,5 @@ export async function track(event: AnalyticsEvent) {
       body: JSON.stringify(event),
       keepalive: true,
     });
-  } catch {
-  }
+  } catch {}
 }


### PR DESCRIPTION
## Changes

- Added `disable_analytics` property for dev testing to not pollute the analytics
- Can be set in the console using `localStorage.setItem("disable_analytics", "true")`

