### PR TITLE
feat: Add maintenance page

### DIFF
--- a/apps/web/src/features/maintenance/MaintenancePage.tsx
+++ b/apps/web/src/features/maintenance/MaintenancePage.tsx
@@ -1,0 +1,27 @@
+import { FallbackLayout } from "@/layouts/fallback/FallbackLayout.tsx";
+
+export function MaintenancePage() {
+  return (
+    <FallbackLayout>
+      <div className="w-full h-full grid grid-cols-12">
+        <div className="flex flex-col col-span-12 items-center justify-center text-center gap-10">
+          <div className="flex flex-col items-center gap-4">
+            <span className="text-7xl lg:text-8xl font-bold text-ludo-white/20 tracking-widest">
+              503
+            </span>
+            <div className="w-12 h-[2px] bg-ludo-accent-dim rounded-full" />
+          </div>
+
+          <div className="flex flex-col gap-3 max-w-md">
+            <h1 className="text-xl lg:text-2xl font-semibold text-ludo-white-bright">
+              We're under maintenance
+            </h1>
+            <p className="text-sm lg:text-base text-ludo-accent-muted">
+              We're making some improvements. Please check back shortly.
+            </p>
+          </div>
+        </div>
+      </div>
+    </FallbackLayout>
+  );
+}

--- a/apps/web/src/queries/definitions/qk.ts
+++ b/apps/web/src/queries/definitions/qk.ts
@@ -1,6 +1,7 @@
 import type { DiscussionTopic } from "@ludocode/types";
 
 export const qk = {
+  maintenance: () => ["maintenance"] as const,
   activeFeatures: () => ["activeFeatures"] as const,
   courses: () => ["courses"] as const,
   careers: () => ["careers"] as const,
@@ -30,7 +31,8 @@ export const qk = {
 
   banners: () => ["banners"] as const,
 
-  discussion: (entityId: string, topic: DiscussionTopic) => ["discussion", topic, entityId] as const,
+  discussion: (entityId: string, topic: DiscussionTopic) =>
+    ["discussion", topic, entityId] as const,
 
   projectsUserPage: (userId: string, page: number, size: number) =>
     ["projects", "user", userId, page, size] as const,

--- a/apps/web/src/queries/definitions/queries.ts
+++ b/apps/web/src/queries/definitions/queries.ts
@@ -40,6 +40,13 @@ import {
 } from "@ludocode/types";
 
 export const qo = {
+  maintenance: () =>
+    queryOptions<{ enabled: boolean }>({
+      queryKey: qk.maintenance(),
+      queryFn: () => ludoGet<{ enabled: boolean }>(api.maintenance.base, false),
+      staleTime: 60_000,
+    }),
+
   user: (userId: string) =>
     queryOptions<LudoUser>({
       queryKey: qk.user(userId),

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,15 +1,21 @@
 import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
-import { type QueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 import { ErrorPage } from "@/features/error/ErrorPage.tsx";
 import { SentryRouteErrorComponent } from "@/features/error/SentryRouteErrorComponent.tsx";
+import { MaintenancePage } from "@/features/maintenance/MaintenancePage.tsx";
+import { qo } from "@/queries/definitions/queries.ts";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
 }>()({
-  beforeLoad: async () => {
+  beforeLoad: async ({ context }) => {
     await sleep(300);
+    const maintenance = await context.queryClient
+      .ensureQueryData(qo.maintenance())
+      .catch(() => ({ enabled: false }));
+    return { maintenance };
   },
   component: RootComponent,
   errorComponent: SentryRouteErrorComponent,
@@ -17,6 +23,12 @@ export const Route = createRootRouteWithContext<{
 });
 
 function RootComponent() {
+  const { data: maintenance } = useQuery(qo.maintenance());
+
+  if (maintenance?.enabled) {
+    return <MaintenancePage />;
+  }
+
   return (
     <div className="w-dvw min-h-dvh max-h-dvh h-dvh overflow-auto scrollbar-ludo-accent bg-ludo-background">
       <Outlet />

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -24,9 +24,15 @@ export function createApiPaths({
       completions: `${BASE}/ai/completions`,
     },
 
+    maintenance: {
+      base: `${BASE}/maintenance`
+    },
+
     analytics: {
       base: `${BASE}/analytics`,
     },
+
+
 
     auth: {
       base: `${BASE}/auth`,


### PR DESCRIPTION
## Summary
This PR adds a maintenance page that is displayed if the backend returns `{enabled: "true"}` at a `/maintenance` endpoint. When the backend has maintenance enabled, it will return a `503` on every other request.

## Changes
- Added `MaintenancePage`
- Added maintenance queries and query key
- Added maintenance api path