### PR TITLE
feat: Improve guided project styling

### DIFF
--- a/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
+++ b/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
@@ -160,6 +160,17 @@ export function GuidedExecutableWorkbench({
     tests,
   ]);
 
+  const runOnly = useCallback(() => {
+    if (!runnerFeature.enabled) return;
+
+    if (isRunning) {
+      stopCode();
+      return;
+    }
+
+    runCode();
+  }, [isRunning, runCode, runnerFeature.enabled, stopCode]);
+
   const runOrAdvance = useCallback(() => {
     if (isComplete) {
       continueToNextExercise();
@@ -248,6 +259,18 @@ export function GuidedExecutableWorkbench({
         incorrectFeedbackMessage={incorrectFeedbackMessage}
         onDismissIncorrectFeedback={dismissIncorrectFeedback}
         isEditorReadOnly={isEditorReadOnly}
+        canReset={canReset}
+        onReset={onReset}
+        solutionHint={
+          showSolutionHint
+            ? {
+                currentCode,
+                solution,
+                languageId,
+                onApplySolution: () => updateContent(solution),
+              }
+            : null
+        }
         className={cn(
           mobilePane === "code" ? "flex-2" : "hidden",
           "transform-none transition-none animate-none",
@@ -259,6 +282,7 @@ export function GuidedExecutableWorkbench({
           onGoBack={onGoBack}
           canReset={canReset}
           onReset={onReset}
+          runOnly={runOnly}
           runOrAdvance={runOrAdvance}
           runnerEnabled={runnerFeature.enabled == true}
           isComplete={isComplete}
@@ -303,6 +327,7 @@ export function GuidedExecutableWorkbench({
             onGoBack={onGoBack}
             canReset={canReset}
             onReset={onReset}
+            runOnly={runOnly}
             runOrAdvance={runOrAdvance}
             runnerEnabled={runnerFeature.enabled == true}
             isComplete={isComplete}

--- a/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
+++ b/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
@@ -286,15 +286,40 @@ export function GuidedExecutableWorkbench({
         )}
       />
 
-      <div className="lg:hidden px-4 py-2 border-t border-ludo-surface">
-        <MobileTabs
-          value={mobilePane}
-          onValueChange={(value) => setMobilePane(value as GuidedMobilePane)}
-        >
-          <MobileTabs.Tab value="instructions">Instructions</MobileTabs.Tab>
-          <MobileTabs.Tab value="code">Code</MobileTabs.Tab>
-          <MobileTabs.Tab value="output">Output</MobileTabs.Tab>
-        </MobileTabs>
+      <div className="lg:hidden border-t border-ludo-surface">
+        <div className="px-4 py-2">
+          <MobileTabs
+            value={mobilePane}
+            onValueChange={(value) => setMobilePane(value as GuidedMobilePane)}
+          >
+            <MobileTabs.Tab value="instructions">Instructions</MobileTabs.Tab>
+            <MobileTabs.Tab value="code">Code</MobileTabs.Tab>
+            <MobileTabs.Tab value="output">Output</MobileTabs.Tab>
+          </MobileTabs>
+        </div>
+        <div className="px-4 w-full flex items-center justify-between gap-2 pb-3 pt-1">
+          <GuidedLessonActions
+            canGoBack={canGoBack}
+            onGoBack={onGoBack}
+            canReset={canReset}
+            onReset={onReset}
+            runOrAdvance={runOrAdvance}
+            runnerEnabled={runnerFeature.enabled == true}
+            isComplete={isComplete}
+            isIncorrect={isIncorrect}
+            isRunning={isRunning}
+            solutionHint={
+              showSolutionHint
+                ? {
+                    currentCode,
+                    solution,
+                    languageId,
+                    onApplySolution: () => updateContent(solution),
+                  }
+                : null
+            }
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
+++ b/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
@@ -81,6 +81,12 @@ export function GuidedExecutableWorkbench({
     }
   }, [currentExercise.id, isMobile]);
 
+  useEffect(() => {
+    if (isMobile && isRunning) {
+      setMobilePane("output");
+    }
+  }, [isMobile, isRunning, setMobilePane]);
+
   const systemPrompt = useMemo(
     () => buildProjectSystemPrompt(currentExercise, project),
     [currentExercise, project],

--- a/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
@@ -71,7 +71,7 @@ export function GuidedExerciseEditorPane({
         />
       )}
 
-      <div className="absolute bottom-16 lg:bottom-10 w-full px-6 lg:px-10 z-10 flex items-center justify-between gap-2">
+      <div className="absolute bottom-16 lg:bottom-10 w-full px-6 lg:px-10 z-10 hidden lg:flex items-center justify-between gap-2">
         {children}
       </div>
     </Workbench.Pane>

--- a/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
@@ -4,8 +4,17 @@ import { ProjectEditor } from "@/features/project/workbench/zones/ProjectEditor"
 import { LudoTab } from "@ludocode/design-system/primitives/tab";
 import { Workbench } from "@ludocode/design-system/widgets/workbench";
 import { GuidedProjectFeedbackPopover } from "./GuidedProjectFeedbackPopover";
+import { SolutionHintDialog } from "./SolutionHintDialog";
 import type { ReactNode } from "react";
 import { cn } from "@ludocode/design-system/cn-utils";
+import { RotateCcwIcon } from "lucide-react";
+
+type SolutionHint = {
+  currentCode: string;
+  solution: string;
+  languageId: string;
+  onApplySolution: () => void;
+};
 
 type GuidedExerciseEditorPaneProps = {
   runOrAdvance: () => void;
@@ -14,6 +23,9 @@ type GuidedExerciseEditorPaneProps = {
   incorrectFeedbackMessage: string | null;
   onDismissIncorrectFeedback: () => void;
   isEditorReadOnly: boolean;
+  canReset: boolean;
+  onReset: () => void;
+  solutionHint?: SolutionHint | null;
   children: ReactNode;
   className?: string;
 };
@@ -25,6 +37,9 @@ export function GuidedExerciseEditorPane({
   incorrectFeedbackMessage,
   onDismissIncorrectFeedback,
   isEditorReadOnly,
+  canReset,
+  onReset,
+  solutionHint,
   children,
   className,
 }: GuidedExerciseEditorPaneProps) {
@@ -55,6 +70,18 @@ export function GuidedExerciseEditorPane({
             );
           })}
         </LudoTab.Group>
+        <div className="flex items-center gap-2 lg:hidden ml-auto">
+          {solutionHint && <SolutionHintDialog {...solutionHint} />}
+          <button
+            type="button"
+            disabled={!canReset}
+            onClick={onReset}
+            className="h-8 w-8 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors disabled:opacity-40 disabled:pointer-events-none"
+            title="Reset code"
+          >
+            <RotateCcwIcon className="h-4 w-4" />
+          </button>
+        </div>
       </Workbench.Pane.Winbar>
 
       <ProjectEditor

--- a/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
@@ -76,7 +76,7 @@ export function GuidedExerciseEditorPane({
             type="button"
             disabled={!canReset}
             onClick={onReset}
-            className="h-8 w-8 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors disabled:opacity-40 disabled:pointer-events-none"
+            className="h-10 w-10 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors disabled:opacity-40 disabled:pointer-events-none"
             title="Reset code"
           >
             <RotateCcwIcon className="h-4 w-4" />

--- a/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
@@ -38,16 +38,14 @@ export function GuidedLessonActions({
   isIncorrect,
   solutionHint,
 }: GuidedLessonActionsProps) {
-  const submitDisabled = !isComplete && !isRunning && !runnerEnabled;
-  const runDisabled = isRunning || !runnerEnabled || isComplete;
+  const submitDisabled = isRunning || (!isComplete && !runnerEnabled);
+  const runDisabled = !runnerEnabled || isComplete;
   const submitLabel =
     isComplete && !isRunning
       ? "CONTINUE"
       : isIncorrect && !isRunning
         ? "RETRY"
-        : isRunning
-          ? "STOP"
-          : "SUBMIT";
+        : "SUBMIT";
 
   return (
     <>
@@ -80,12 +78,12 @@ export function GuidedLessonActions({
         </div>
         <LudoButton
           onClick={runOnly}
-          variant="default"
+          variant={isRunning ? "default" : "alt"}
           shadow={false}
           disabled={runDisabled}
           className={cn("h-10 py-0.5 lg:px-4 min-w-20 lg:min-w-24")}
         >
-          RUN
+          {isRunning ? "STOP" : "RUN"}
         </LudoButton>
         <LudoButton
           data-testid={testIds.guided.runCodeButton}

--- a/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
@@ -17,6 +17,7 @@ type GuidedLessonActionsProps = {
   canReset: boolean;
   onReset: () => void;
   isRunning: boolean;
+  runOnly: () => void;
   runOrAdvance: () => void;
   runnerEnabled: boolean;
   isComplete: boolean;
@@ -31,17 +32,19 @@ export function GuidedLessonActions({
   onReset,
   isRunning,
   runnerEnabled,
+  runOnly,
   runOrAdvance,
   isComplete,
   isIncorrect,
   solutionHint,
 }: GuidedLessonActionsProps) {
-  const runButtonDisabled = !isComplete && !isRunning && !runnerEnabled;
-  const actionLabel =
+  const submitDisabled = !isComplete && !isRunning && !runnerEnabled;
+  const runDisabled = isRunning || !runnerEnabled || isComplete;
+  const submitLabel =
     isComplete && !isRunning
       ? "CONTINUE"
       : isIncorrect && !isRunning
-        ? "TRY AGAIN"
+        ? "RETRY"
         : isRunning
           ? "STOP"
           : "SUBMIT";
@@ -66,22 +69,33 @@ export function GuidedLessonActions({
           shadow={false}
           disabled={!canReset}
           onClick={onReset}
-          className="h-10 px-4"
+          className="h-10 px-4 hidden lg:flex"
         >
           <RotateCcwIcon className="h-4 w-4" />
         </LudoButton>
       </div>
       <div className="h-10 flex items-center gap-2">
-        {solutionHint && <SolutionHintDialog {...solutionHint} />}
+        <div className="hidden lg:block">
+          {solutionHint && <SolutionHintDialog {...solutionHint} />}
+        </div>
+        <LudoButton
+          onClick={runOnly}
+          variant="default"
+          shadow={false}
+          disabled={runDisabled}
+          className={cn("h-10 py-0.5 lg:px-4 min-w-20 lg:min-w-24")}
+        >
+          RUN
+        </LudoButton>
         <LudoButton
           data-testid={testIds.guided.runCodeButton}
           onClick={runOrAdvance}
           variant={isRunning ? "default" : "alt"}
           shadow={false}
-          disabled={runButtonDisabled}
+          disabled={submitDisabled}
           className={cn("h-10 py-0.5 lg:px-4 min-w-24 lg:min-w-34")}
         >
-          {actionLabel}
+          {submitLabel}
         </LudoButton>
       </div>
     </>

--- a/apps/web/src/features/lesson/guided/components/GuidedProjectFeedbackPopover.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedProjectFeedbackPopover.tsx
@@ -17,11 +17,11 @@ export function GuidedProjectFeedbackPopover({
   return (
     <div
       className={cn(
-        "absolute z-10 bottom-30 lg:bottom-22 right-10 min-w-56 max-w-80 rounded-md border bg-ludo-background px-3 py-2",
+        "absolute z-10 bottom-4 lg:bottom-22 left-4 lg:right-10 lg:left-auto min-w-56 max-w-80 rounded-md border bg-ludo-background px-3 py-2",
         showCorrectFeedback ? "border-ludo-correct" : "border-ludo-incorrect",
       )}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex justify-between items-center gap-3">
         <p className="text-sm text-ludo-white-bright">
           {showCorrectFeedback
             ? "Great work!"

--- a/apps/web/src/features/lesson/guided/components/SolutionHintDialog.tsx
+++ b/apps/web/src/features/lesson/guided/components/SolutionHintDialog.tsx
@@ -37,7 +37,7 @@ export function SolutionHintDialog({
       trigger={
         <button
           type="button"
-          className="h-10 hover:cursor-pointer w-16 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors"
+          className="h-10 hover:cursor-pointer w-10 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors"
           title="View reference solution"
         >
           <LightbulbIcon className="h-5 w-5" />

--- a/apps/web/src/features/project/workbench/WorkbenchPage.tsx
+++ b/apps/web/src/features/project/workbench/WorkbenchPage.tsx
@@ -56,6 +56,7 @@ export function WorkbenchPage({
         <WorkbenchPageContent
           projectId={project.projectId}
           isWebProject={isWebProject}
+          entryFilePath={project.entryFilePath}
           previewRefreshVersion={saveSuccessCount}
           readOnly={readOnly}
           authenticated={authenticated}
@@ -72,6 +73,7 @@ export function WorkbenchPage({
 
 function WorkbenchPageContent({
   projectId,
+  entryFilePath,
   isWebProject,
   previewRefreshVersion,
   readOnly,
@@ -83,6 +85,7 @@ function WorkbenchPageContent({
   runnerEnabled,
 }: {
   projectId: string;
+  entryFilePath: string;
   isWebProject: boolean;
   previewRefreshVersion: number;
   readOnly: boolean;
@@ -123,6 +126,7 @@ function WorkbenchPageContent({
 
       {isWebProject ? (
         <WorkbenchLivePreviewPane
+          filePath={entryFilePath}
           projectId={projectId}
           refreshVersion={previewRefreshVersion}
           className={cn(

--- a/apps/web/src/features/project/workbench/components/FileActionsMenu.tsx
+++ b/apps/web/src/features/project/workbench/components/FileActionsMenu.tsx
@@ -12,6 +12,7 @@ type FileActionsMenuProps = {
   renameItem: (oldPath: string, newPath: string) => void;
   deleteItem: () => void;
   canDelete?: boolean;
+  canRename?: boolean;
 };
 
 export function FileActionsMenu({
@@ -22,30 +23,33 @@ export function FileActionsMenu({
   itemType,
   deleteItem,
   canDelete = true,
+  canRename = true,
 }: FileActionsMenuProps) {
   return (
     <LudoMenu>
       <LudoMenu.Trigger>{trigger}</LudoMenu.Trigger>
 
-      <LudoMenu.Content align="end">
-        <RenameDialog
-          itemCategory={itemType}
-          key={`rename-${targetId}`}
-          itemName={targetName}
-          onSubmit={renameItem}
-        >
-          <LudoMenu.Item closeOnSelect={false}>
-            <LudoMenu.Row>
-              <LudoMenu.Icon>
-                <HeroIcon
-                  iconName="PencilIcon"
-                  className="h-4 text-ludo-white-bright/70"
-                />
-              </LudoMenu.Icon>
-              <LudoMenu.Label>Rename</LudoMenu.Label>
-            </LudoMenu.Row>
-          </LudoMenu.Item>
-        </RenameDialog>
+      <LudoMenu.Content  align="end">
+        {canRename && (
+          <RenameDialog
+            itemCategory={itemType}
+            key={`rename-${targetId}`}
+            itemName={targetName}
+            onSubmit={renameItem}
+          >
+            <LudoMenu.Item closeOnSelect={false}>
+              <LudoMenu.Row>
+                <LudoMenu.Icon>
+                  <HeroIcon
+                    iconName="PencilIcon"
+                    className="h-4 text-ludo-white-bright/70"
+                  />
+                </LudoMenu.Icon>
+                <LudoMenu.Label>Rename</LudoMenu.Label>
+              </LudoMenu.Row>
+            </LudoMenu.Item>
+          </RenameDialog>
+        )}
 
         {canDelete && (
           <>

--- a/apps/web/src/features/project/workbench/components/WorkbenchMobileTabs.tsx
+++ b/apps/web/src/features/project/workbench/components/WorkbenchMobileTabs.tsx
@@ -27,6 +27,12 @@ export function WorkbenchMobileTabs({
   const [hasUnreadOutput, setHasUnreadOutput] = useState(false);
 
   useEffect(() => {
+    if (isRunning) {
+      setMobilePane("output");
+    }
+  }, [isRunning, setMobilePane]);
+
+  useEffect(() => {
     if (isRunning || outputLog.length > 0) {
       setHasUnreadOutput(true);
     }

--- a/apps/web/src/features/project/workbench/zones/WorkbenchLivePreviewPane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchLivePreviewPane.tsx
@@ -7,25 +7,27 @@ import { testIds } from "@ludocode/util";
 
 type WorkbenchLivePreviewPaneProps = {
     projectId: string;
+    filePath: string;
     className?: string;
     refreshVersion?: number;
     hideWinbarOnMobile?: boolean;
 };
 
-function buildPreviewUrl(projectId: string): string {
+function buildPreviewUrl(projectId: string, filePath: string = "index.html"): string {
     const base = (WEB_CDN_BASE_URL ?? "").trim().replace(/\/+$/, "");
     if (!base || !projectId) return "";
-    return `${base}/${projectId}/index.html`;
+    return `${base}/${projectId}/${filePath}`;
 }
 
 export function WorkbenchLivePreviewPane({
     projectId,
+    filePath,
     refreshVersion = 0,
     className,
     hideWinbarOnMobile = false,
 }: WorkbenchLivePreviewPaneProps) {
     const [manualRefreshVersion, setManualRefreshVersion] = useState(0);
-    const previewUrl = buildPreviewUrl(projectId);
+    const previewUrl = buildPreviewUrl(projectId, filePath);
     const iframeSrc =
         previewUrl.length > 0
             ? `${previewUrl}${previewUrl.includes("?") ? "&" : "?"}autosave=${refreshVersion}&refresh=${manualRefreshVersion}`

--- a/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
@@ -103,6 +103,10 @@ export function WorkbenchTreePane({
             {files.map((file) => {
               const key = file.tempId ?? file.path;
               const isEntryFile = file.path === entryFileId;
+
+              const canDelete = canDeleteFiles && !isEntryFile
+              const canRename = !isEntryFile
+
               return (
                 <LudoFileTree.Item
                   dataTestId={testIds.project.treeFile(file.path)}
@@ -113,7 +117,7 @@ export function WorkbenchTreePane({
                     isEntryFile ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <span className="flex items-center">
+                          <span className="flex mr-1 items-center">
                             <Play className="h-3 w-3 fill-amber-400 text-amber-400" />
                           </span>
                         </TooltipTrigger>
@@ -131,8 +135,9 @@ export function WorkbenchTreePane({
                     />
                   }
                   actions={
-                    !readOnly && (
+                    !readOnly && (canDelete || canRename) && (
                       <FileActionsMenu
+                        canRename={!isEntryFile}
                         canDelete={canDeleteFiles && !isEntryFile}
                         trigger={
                           <div


### PR DESCRIPTION
## Summary

This PR adds a seperate "run" button on guided lessons so users can test their code before submitting. It also rearranges actions on the mobile version so they are less cluttered in the bottom row. Finally, this PR prevents renaming the entry file on web projects (should stay index.html, there are small bugs when name changes).