### PR TITLE
refactor: Increase column count of avatar grid on larger devices

### DIFF
--- a/apps/web/src/features/user/profile/AvatarPage.tsx
+++ b/apps/web/src/features/user/profile/AvatarPage.tsx
@@ -38,7 +38,7 @@ export function AvatarPage() {
           <p className="text-xs uppercase tracking-widest text-ludo-white/70 font-semibold mb-4">
             Choose Avatar
           </p>
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-4 lg:grid-cols-6 gap-3">
             {avatarIndices.map((index) => {
               const isSelected = index === selectedIndex;
               const src = getUserAvatar(AVATAR_VERSION, index);

--- a/apps/web/src/features/user/profile/AvatarPage.tsx
+++ b/apps/web/src/features/user/profile/AvatarPage.tsx
@@ -38,7 +38,7 @@ export function AvatarPage() {
           <p className="text-xs uppercase tracking-widest text-ludo-white/70 font-semibold mb-4">
             Choose Avatar
           </p>
-          <div className="grid grid-cols-4 lg:grid-cols-6 gap-3">
+          <div className="grid grid-cols-4 lg:grid-cols-6 2xl:grid-cols-12 gap-3">
             {avatarIndices.map((index) => {
               const isSelected = index === selectedIndex;
               const src = getUserAvatar(AVATAR_VERSION, index);


### PR DESCRIPTION
## Summary
This PR adds additional columns on lg and 2xl breakpoints on the avatars in the avatar page. 

- lg = 6 cols
- 2xl = 12 cols