### PR TITLE
refactor: Streamline playwright tests & add guided lesson tests

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
+  /* Tests that complete entire courses with guided lessons can take a while */
+  timeout: 120_000,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */

--- a/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
@@ -93,7 +93,9 @@ export function GuidedLessonActions({
           disabled={submitDisabled}
           className={cn("h-10 py-0.5 lg:px-4 min-w-24 lg:min-w-34")}
         >
-          {submitLabel}
+          <span data-testid={testIds.guided.runCodeButtonText}>
+            {submitLabel}
+          </span>
         </LudoButton>
       </div>
     </>

--- a/apps/web/src/features/lesson/guided/components/GuidedProjectFeedbackPopover.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedProjectFeedbackPopover.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@ludocode/design-system/cn-utils";
 import { X } from "lucide-react";
+import { testIds } from "@ludocode/util/test-ids";
 
 type GuidedProjectFeedbackPopoverProps = {
   incorrectFeedbackMessage: string | null;
@@ -16,6 +17,11 @@ export function GuidedProjectFeedbackPopover({
 }: GuidedProjectFeedbackPopoverProps) {
   return (
     <div
+      data-testid={
+        showCorrectFeedback
+          ? testIds.guided.feedbackCorrect
+          : testIds.guided.feedbackIncorrect
+      }
       className={cn(
         "absolute z-10 bottom-4 lg:bottom-22 left-4 lg:right-10 lg:left-auto min-w-56 max-w-80 rounded-md border bg-ludo-background px-3 py-2",
         showCorrectFeedback ? "border-ludo-correct" : "border-ludo-incorrect",

--- a/apps/web/src/features/modules/hub/navigator/MobileModuleSlideOver.tsx
+++ b/apps/web/src/features/modules/hub/navigator/MobileModuleSlideOver.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { LudoList } from "@ludocode/design-system/widgets/ludo-list.tsx";
 import { FloatingMobileTrigger } from "@ludocode/design-system/primitives/FloatingMobileTrigger.tsx";
 import { LudoSlideOver } from "@ludocode/design-system/widgets/ludo-slideover.tsx";
+import { testIds } from "@ludocode/util/test-ids";
 type MobileModuleSlideOverProps = {
   modules: LudoModule[];
   courseId: string;
@@ -79,6 +80,7 @@ export function MobileModuleSlideOver({
                     position={module.orderIndex}
                     title={module.title}
                     isComplete={isComplete}
+                    dataTestId={testIds.module.item(module.id)}
                   />
                 );
               })}

--- a/apps/web/src/features/modules/hub/navigator/ModuleNavigator.tsx
+++ b/apps/web/src/features/modules/hub/navigator/ModuleNavigator.tsx
@@ -3,6 +3,7 @@ import type { ModuleProgress } from "@/features/modules/hooks/useTreeData.tsx";
 import { CourseCard } from "@/features/course/hub/components/CourseCard.tsx";
 import { LudoList } from "@ludocode/design-system/widgets/ludo-list.tsx";
 import { ChangeCourseButton } from "./ChangeCourseButton.tsx";
+import { testIds } from "@ludocode/util/test-ids";
 
 type ModuleNavigatorProps = {
   modules: LudoModule[];
@@ -48,6 +49,7 @@ export function ModuleNavigator({
                 }}
                 isActive={isActive}
                 onClick={() => selectModule(module.id)}
+                dataTestId={testIds.module.item(module.id)}
               />
             );
           })}
@@ -55,7 +57,7 @@ export function ModuleNavigator({
       </div>
 
       <div className="pt-2">
-        <ChangeCourseButton/>
+        <ChangeCourseButton />
       </div>
     </LudoList>
   );

--- a/apps/web/src/features/modules/hub/path/ModulePath.tsx
+++ b/apps/web/src/features/modules/hub/path/ModulePath.tsx
@@ -55,6 +55,7 @@ export function ModulePath({
         <LudoPath.Row className="mt-10" index={normalLessonCount}>
           <LudoPath.NextButton
             title={nextModuleTitle}
+            dataTestId={testIds.module.nextButton}
             onClick={() =>
               router.navigate(
                 ludoNavigation.hub.module.toModule(courseId, nextModuleId),

--- a/apps/web/tests/completion.spec.ts
+++ b/apps/web/tests/completion.spec.ts
@@ -1,10 +1,19 @@
 import { test, expect } from "@playwright/test";
 import { initialiseUser } from "./utils/initialise";
-import { goToLesson, completeLessonPerfect } from "./utils/lesson";
+import {
+  goToLesson,
+  completeLessonPerfect,
+  clickThroughCompletion,
+  completeCourse,
+} from "./utils/lesson";
 import { testIds } from "@ludocode/util/test-ids.js";
-import { getAllLessons } from "./utils/course";
+import {
+  getAllLessons,
+  getModuleLessons,
+  navigateToModule,
+} from "./utils/course";
 
-test("user completes lesson for the first time ever, shows completion, streak, & courseComplete", async ({
+test("user completes first lesson and sees lesson completion & streak", async ({
   page,
 }) => {
   const ctx = await initialiseUser(page);
@@ -13,7 +22,6 @@ test("user completes lesson for the first time ever, shows completion, streak, &
   const exercises = await goToLesson(page, firstLesson.id);
   await completeLessonPerfect(page, exercises);
 
-  // After sync, should land on completion page with lesson step
   await expect(page).toHaveURL(/\/completion\/.*\?step=lesson/);
 
   const completionButton = page.getByTestId(testIds.completion.button);
@@ -41,6 +49,58 @@ test("user completes lesson for the first time ever, shows completion, streak, &
   await expect(completionButton).toBeVisible();
 
   await completionButton.click();
+
+  await expect(page).toHaveURL(/\/app\/learn\//);
+});
+
+test("user completes entire course and sees course complete screen", async ({
+  page,
+}) => {
+  const ctx = await initialiseUser(page);
+
+  const allLessons = getAllLessons(ctx);
+  const allButLast = allLessons.slice(0, -1);
+  const lastLesson = allLessons[allLessons.length - 1];
+
+  for (let mi = 0; mi < ctx.modules.length; mi++) {
+    const mod = ctx.modules[mi];
+    const lessons = getModuleLessons(mod);
+
+    if (mi > 0) {
+      await navigateToModule(page, mod.id);
+    }
+
+    for (const lesson of lessons) {
+      if (lesson.id === lastLesson.id) continue;
+
+      const exercises = await goToLesson(page, lesson.id);
+      await completeLessonPerfect(page, exercises);
+      await clickThroughCompletion(page);
+    }
+  }
+
+  const lastModule = ctx.modules[ctx.modules.length - 1];
+  if (ctx.modules.length > 1) {
+    const currentUrl = page.url();
+    if (!currentUrl.includes(lastModule.id)) {
+      await navigateToModule(page, lastModule.id);
+    }
+  }
+
+  const exercises = await goToLesson(page, lastLesson.id);
+  await completeLessonPerfect(page, exercises);
+
+  await expect(page).toHaveURL(/\/completion\/.*\?step=lesson/);
+
+  const completionButton = page.getByTestId(testIds.completion.button);
+  await expect(completionButton).toBeVisible();
+  await completionButton.click();
+
+  while (!page.url().includes("step=course")) {
+    await expect(completionButton).toBeVisible();
+    await completionButton.click();
+    await page.waitForURL(/step=(streak|course)/);
+  }
 
   await expect(page).toHaveURL(/step=course/);
 

--- a/apps/web/tests/completion.spec.ts
+++ b/apps/web/tests/completion.spec.ts
@@ -1,21 +1,20 @@
 import { test, expect } from "@playwright/test";
 import { initialiseUser } from "./utils/initialise";
-import {
-  completeLessonPerfect,
-  goToLesson,
-} from "./utils/lesson";
-import {testIds} from "@ludocode/util/test-ids.js"
+import { goToLesson, completeLessonPerfect } from "./utils/lesson";
+import { testIds } from "@ludocode/util/test-ids.js";
+import { getAllLessons } from "./utils/course";
 
 test("user completes lesson for the first time ever, shows completion, streak, & courseComplete", async ({
   page,
 }) => {
-  await initialiseUser(page);
-  await goToLesson(page);
-  await completeLessonPerfect(page);
+  const ctx = await initialiseUser(page);
+  const firstLesson = getAllLessons(ctx)[0];
 
-  await expect(page).toHaveURL(
-    /\/completion\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?step=lesson&coins=20&accuracy=1&xpGained=10&oldStreak=0&newStreak=1&completionStatus=COURSE_COMPLETE$/,
-  );
+  const exercises = await goToLesson(page, firstLesson.id);
+  await completeLessonPerfect(page, exercises);
+
+  // After sync, should land on completion page with lesson step
+  await expect(page).toHaveURL(/\/completion\/.*\?step=lesson/);
 
   const completionButton = page.getByTestId(testIds.completion.button);
 
@@ -27,8 +26,8 @@ test("user completes lesson for the first time ever, shows completion, streak, &
   await expect(xp).toBeVisible();
   await expect(accuracy).toBeVisible();
 
-  await expect(xp).toContainText("+10");
-  await expect(accuracy).toContainText("100%");
+  await expect(xp).toContainText("+");
+  await expect(accuracy).toContainText("%");
 
   await completionButton.click();
 
@@ -58,13 +57,8 @@ test("user completes lesson for the first time ever, shows completion, streak, &
   await expect(courseCompleteBadgeText).toBeVisible();
   await expect(courseCompleteCongratulation).toBeVisible();
   await expect(courseCompleteHeader).toContainText("Course Complete!");
-  await expect(courseCompleteBadgeText).toContainText(
-    "You've earned the Python badge!",
-  );
 
   await completionButton.click();
 
-  await expect(page).toHaveURL(
-    /\/app\/learn\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f$/,
-  );
+  await expect(page).toHaveURL(/\/app\/learn\//);
 });

--- a/apps/web/tests/guidedLesson.spec.ts
+++ b/apps/web/tests/guidedLesson.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+import { initialiseUser } from "./utils/initialise";
+import {
+  goToLesson,
+  completeLessonPerfect,
+  completeLessonsUpTo,
+  isGuidedLesson,
+} from "./utils/lesson";
+import { setMonacoValue } from "./utils/monaco";
+import { testIds } from "@ludocode/util/test-ids.js";
+import { getFirstGuidedLesson } from "./utils/course";
+
+test.describe("guided lessons", () => {
+  test("course has a guided lesson available", async ({ page }) => {
+    const ctx = await initialiseUser(page);
+
+    const guidedLesson = getFirstGuidedLesson(ctx);
+    expect(guidedLesson).toBeDefined();
+    expect(guidedLesson.id).toBeTruthy();
+  });
+
+  test("user can navigate to a guided lesson", async ({ page }) => {
+    const ctx = await initialiseUser(page);
+    const guidedLesson = getFirstGuidedLesson(ctx);
+
+    await completeLessonsUpTo(page, ctx, guidedLesson.id);
+
+    const exercises = await goToLesson(page, guidedLesson.id);
+
+    await expect(page).toHaveURL(
+      new RegExp(`/lesson/${ctx.courseId}/.*/${guidedLesson.id}\\?exercise=1$`),
+    );
+
+    expect(isGuidedLesson(exercises)).toBe(true);
+
+    const guidedSubmitButton = page
+      .getByTestId(testIds.guided.runCodeButton)
+      .first();
+    await expect(guidedSubmitButton).toBeVisible();
+  });
+
+  test("user can complete a guided lesson with correct solution", async ({
+    page,
+  }) => {
+    const ctx = await initialiseUser(page);
+    const guidedLesson = getFirstGuidedLesson(ctx);
+
+    await completeLessonsUpTo(page, ctx, guidedLesson.id);
+
+    const exercises = await goToLesson(page, guidedLesson.id);
+
+    await completeLessonPerfect(page, exercises);
+
+    await expect(page).toHaveURL(/\/completion\//);
+  });
+
+  test("user sees RETRY when submitting wrong code in guided lesson", async ({
+    page,
+  }) => {
+    const ctx = await initialiseUser(page);
+    const guidedLesson = getFirstGuidedLesson(ctx);
+
+    await completeLessonsUpTo(page, ctx, guidedLesson.id);
+
+    const exercises = await goToLesson(page, guidedLesson.id);
+
+    const execExercise = exercises.find(
+      (e) => e.interaction?.type === "EXECUTABLE",
+    );
+    expect(execExercise).toBeDefined();
+
+    const guidedSubmitButton = page
+      .getByTestId(testIds.guided.runCodeButton)
+      .first();
+    for (const exercise of exercises) {
+      if (exercise.id === execExercise!.id) break;
+      if (!exercise.interaction) {
+        await expect(guidedSubmitButton).toBeVisible();
+        await guidedSubmitButton.click();
+      }
+    }
+
+    const guidedSubmitText = page
+      .getByTestId(testIds.guided.runCodeButtonText)
+      .first();
+    const runner = page.getByTestId(testIds.project.runner);
+
+    await setMonacoValue(page, "# this is intentionally wrong");
+    await page.waitForTimeout(500);
+    await expect(guidedSubmitButton).toBeVisible();
+    await guidedSubmitButton.click();
+
+    await expect(guidedSubmitText).toContainText("RETRY", { timeout: 30_000 });
+
+    const feedbackIncorrect = page.getByTestId(
+      testIds.guided.feedbackIncorrect,
+    );
+    await expect(feedbackIncorrect).toBeVisible();
+
+    await expect(runner).toBeVisible();
+
+    const solution =
+      execExercise!.interaction?.type === "EXECUTABLE"
+        ? execExercise!.interaction.solution
+        : "";
+    await setMonacoValue(page, solution);
+    await page.waitForTimeout(500);
+    await guidedSubmitButton.click();
+
+    await expect(guidedSubmitText).toContainText("CONTINUE", {
+      timeout: 30_000,
+    });
+
+    const feedbackCorrect = page.getByTestId(testIds.guided.feedbackCorrect);
+    await expect(feedbackCorrect).toBeVisible();
+  });
+});

--- a/apps/web/tests/initialisation.spec.ts
+++ b/apps/web/tests/initialisation.spec.ts
@@ -5,15 +5,6 @@ test("user can register, onboard, & is taken to their desired course", async ({
   page,
 }) => {
   await onboardUser(page);
-  // const freeButton = page.getByTestId(testIds.subscription.compare("FREE"));
 
-  // await expect(page).toHaveURL(/\/app\/subscription\/comparison$/);
-
-  // await expect(freeButton).toBeVisible();
-
-  // await freeButton.click();
-
-  await expect(page).toHaveURL(
-    /\/app\/learn\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f$/,
-  );
+  await expect(page).toHaveURL(/\/app\/learn\/[^/]+\/[^/]+$/);
 });

--- a/apps/web/tests/lesson.spec.ts
+++ b/apps/web/tests/lesson.spec.ts
@@ -1,14 +1,16 @@
 import { test, expect } from "@playwright/test";
 import { initialiseUser } from "./utils/initialise";
-import { goToLesson } from "./utils/lesson";
-import {testIds} from "@ludocode/util/test-ids.js"
+import { goToLesson, completeLessonPerfect } from "./utils/lesson";
+import { testIds } from "@ludocode/util/test-ids.js";
+import { getAllLessons, getModuleForLesson } from "./utils/course";
 
 test("user can go to lesson", async ({ page }) => {
-  await initialiseUser(page);
-  const lessonId = "7eeaaddd-2d87-495e-bd40-24cfd9f06b4b";
-  const pathButton = page.getByTestId(testIds.path.button(lessonId));
+  const ctx = await initialiseUser(page);
+  const firstLesson = getAllLessons(ctx)[0];
+
+  const pathButton = page.getByTestId(testIds.path.button(firstLesson.id));
   const pathPopoverButton = page.getByTestId(
-    testIds.path.popoverButton(lessonId),
+    testIds.path.popoverButton(firstLesson.id),
   );
 
   await expect(pathButton).toBeVisible();
@@ -18,51 +20,18 @@ test("user can go to lesson", async ({ page }) => {
 
   await pathPopoverButton.click();
 
-  await expect(page).toHaveURL(
-    /\/lesson\/.*7eeaaddd-2d87-495e-bd40-24cfd9f06b4b.*/,
-  );
+  await expect(page).toHaveURL(new RegExp(`/lesson/.*${firstLesson.id}`));
 });
 
 test("user can go to lesson & complete it", async ({ page }) => {
-  await initialiseUser(page);
-  await goToLesson(page);
+  const ctx = await initialiseUser(page);
+  const firstLesson = getAllLessons(ctx)[0];
+
+  const exercises = await goToLesson(page, firstLesson.id);
 
   await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=1$/,
+    new RegExp(`/lesson/${ctx.courseId}/.*/${firstLesson.id}\\?exercise=1$`),
   );
 
-  const submitButton = page.getByTestId(testIds.lesson.submitButton);
-  await expect(submitButton).toBeVisible();
-  await submitButton.click();
-
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=2$/,
-  );
-
-  const submitButtonText = page.getByTestId(testIds.lesson.submitText);
-
-  const secondExerciseCorrectOption = page.getByTestId(
-    testIds.exercise.option("+"),
-  );
-  const secondExerciseDistractor = page.getByTestId(
-    testIds.exercise.option("="),
-  );
-  await expect(secondExerciseDistractor).toBeVisible();
-  await expect(secondExerciseCorrectOption).toBeVisible();
-  await secondExerciseDistractor.click();
-  await submitButton.click();
-  await expect(submitButtonText).toContainText("TRY AGAIN");
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=2$/,
-  );
-  await submitButton.click();
-
-  await expect(submitButtonText).toContainText("CHECK");
-
-  await secondExerciseCorrectOption.click();
-  await submitButton.click();
-  await expect(submitButtonText).toContainText("CONTINUE");
-  await submitButton.click();
-
-  await expect(page).toHaveURL(/\/sync\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b/);
+  await completeLessonPerfect(page, exercises);
 });

--- a/apps/web/tests/utils/course.ts
+++ b/apps/web/tests/utils/course.ts
@@ -1,0 +1,99 @@
+import { type Page, expect } from "@playwright/test";
+import { testIds } from "@ludocode/util/test-ids.js";
+import type { LudoExercise } from "@ludocode/types";
+
+// ── Types mirrored from FlatCourseTree ──────────────────────
+type FlatLesson = { id: string; orderIndex: number };
+type FlatModule = { id: string; orderIndex: number; lessons: FlatLesson[] };
+type FlatCourseTree = { courseId: string; modules: FlatModule[] };
+
+// ── Course context captured via API interception ────────────
+export type CourseContext = {
+  courseId: string;
+  modules: FlatModule[];
+};
+
+/**
+ * Intercepts the course-tree API call to capture the course structure
+ * (courseId, modules, lessons) dynamically.
+ *
+ * Must be called **before** navigating to the learn page.
+ */
+export async function interceptCourseTree(page: Page): Promise<CourseContext> {
+  return new Promise<CourseContext>((resolve) => {
+    page.route("**/api/v1/catalog/courses/*/tree", async (route) => {
+      const response = await route.fetch();
+      const tree: FlatCourseTree = await response.json();
+      resolve({
+        courseId: tree.courseId,
+        modules: tree.modules.sort((a, b) => a.orderIndex - b.orderIndex),
+      });
+      await route.fulfill({ response });
+    });
+  });
+}
+
+/**
+ * Returns all lessons across all modules, sorted by module then lesson order.
+ */
+export function getAllLessons(ctx: CourseContext): FlatLesson[] {
+  return ctx.modules.flatMap((m) =>
+    [...m.lessons].sort((a, b) => a.orderIndex - b.orderIndex),
+  );
+}
+
+/**
+ * Returns the first module in the course tree.
+ */
+export function getFirstModule(ctx: CourseContext): FlatModule {
+  return ctx.modules[0];
+}
+
+/**
+ * Returns the module that contains the given lesson.
+ */
+export function getModuleForLesson(
+  ctx: CourseContext,
+  lessonId: string,
+): FlatModule {
+  const mod = ctx.modules.find((m) => m.lessons.some((l) => l.id === lessonId));
+  if (!mod) throw new Error(`No module found containing lesson ${lessonId}`);
+  return mod;
+}
+
+// ── Exercise data captured via API interception ─────────────
+
+/**
+ * Intercepts the exercises API call for a lesson and returns the exercises.
+ *
+ * Must be called **before** navigating to the lesson page.
+ * Resolves when the API response is captured.
+ */
+export function interceptExercises(page: Page): Promise<LudoExercise[]> {
+  return new Promise<LudoExercise[]>((resolve) => {
+    page.route("**/api/v1/lessons/*/exercises", async (route) => {
+      const response = await route.fetch();
+      const exercises: LudoExercise[] = await response.json();
+      resolve(exercises.sort((a, b) => a.orderIndex - b.orderIndex));
+      await route.fulfill({ response });
+    });
+  });
+}
+
+/**
+ * Navigates to a lesson from the learn/module page by clicking
+ * the path button and popover button.
+ */
+export async function navigateToLesson(page: Page, lessonId: string) {
+  const pathButton = page.getByTestId(testIds.path.button(lessonId));
+  const pathPopoverButton = page.getByTestId(
+    testIds.path.popoverButton(lessonId),
+  );
+
+  await expect(pathButton).toBeVisible();
+  await pathButton.click();
+  await expect(pathPopoverButton).toBeVisible();
+  await pathPopoverButton.click();
+
+  await expect(page).toHaveURL(new RegExp(`/lesson/.*${lessonId}`));
+}

--- a/apps/web/tests/utils/course.ts
+++ b/apps/web/tests/utils/course.ts
@@ -1,57 +1,57 @@
 import { type Page, expect } from "@playwright/test";
 import { testIds } from "@ludocode/util/test-ids.js";
-import type { LudoExercise } from "@ludocode/types";
+import type { LudoExercise, LudoLesson } from "@ludocode/types";
 
-// ── Types mirrored from FlatCourseTree ──────────────────────
 type FlatLesson = { id: string; orderIndex: number };
 type FlatModule = { id: string; orderIndex: number; lessons: FlatLesson[] };
 type FlatCourseTree = { courseId: string; modules: FlatModule[] };
 
-// ── Course context captured via API interception ────────────
 export type CourseContext = {
   courseId: string;
   modules: FlatModule[];
+  lessonDetails: LudoLesson[];
 };
 
-/**
- * Intercepts the course-tree API call to capture the course structure
- * (courseId, modules, lessons) dynamically.
- *
- * Must be called **before** navigating to the learn page.
- */
 export async function interceptCourseTree(page: Page): Promise<CourseContext> {
+  const ctx: CourseContext = {
+    courseId: "",
+    modules: [],
+    lessonDetails: [],
+  };
+
   return new Promise<CourseContext>((resolve) => {
     page.route("**/api/v1/catalog/courses/*/tree", async (route) => {
       const response = await route.fetch();
       const tree: FlatCourseTree = await response.json();
-      resolve({
-        courseId: tree.courseId,
-        modules: tree.modules.sort((a, b) => a.orderIndex - b.orderIndex),
-      });
+      ctx.courseId = tree.courseId;
+      ctx.modules = tree.modules.sort((a, b) => a.orderIndex - b.orderIndex);
+
+      const allLessonIds = ctx.modules.flatMap((m) =>
+        m.lessons.map((l) => l.id),
+      );
+      if (allLessonIds.length > 0) {
+        const baseUrl = new URL(route.request().url()).origin;
+        const resp = await page.request.get(
+          `${baseUrl}/api/v1/lessons?lessonIds=${allLessonIds.join(",")}`,
+        );
+        ctx.lessonDetails = await resp.json();
+      }
+
+      resolve(ctx);
       await route.fulfill({ response });
     });
   });
 }
 
-/**
- * Returns all lessons across all modules, sorted by module then lesson order.
- */
 export function getAllLessons(ctx: CourseContext): FlatLesson[] {
   return ctx.modules.flatMap((m) =>
     [...m.lessons].sort((a, b) => a.orderIndex - b.orderIndex),
   );
 }
-
-/**
- * Returns the first module in the course tree.
- */
 export function getFirstModule(ctx: CourseContext): FlatModule {
   return ctx.modules[0];
 }
 
-/**
- * Returns the module that contains the given lesson.
- */
 export function getModuleForLesson(
   ctx: CourseContext,
   lessonId: string,
@@ -61,14 +61,26 @@ export function getModuleForLesson(
   return mod;
 }
 
-// ── Exercise data captured via API interception ─────────────
+export function getFirstGuidedLesson(ctx: CourseContext): FlatLesson {
+  const guidedDetail = ctx.lessonDetails.find((l) => l.lessonType === "GUIDED");
+  if (!guidedDetail) throw new Error("No guided lesson found in course");
 
-/**
- * Intercepts the exercises API call for a lesson and returns the exercises.
- *
- * Must be called **before** navigating to the lesson page.
- * Resolves when the API response is captured.
- */
+  const flat = getAllLessons(ctx).find((l) => l.id === guidedDetail.id);
+  if (!flat)
+    throw new Error(`Guided lesson ${guidedDetail.id} not in course tree`);
+  return flat;
+}
+
+export function getFirstNormalLesson(ctx: CourseContext): FlatLesson {
+  const normalDetail = ctx.lessonDetails.find((l) => l.lessonType === "NORMAL");
+  if (!normalDetail) throw new Error("No normal lesson found in course");
+
+  const flat = getAllLessons(ctx).find((l) => l.id === normalDetail.id);
+  if (!flat)
+    throw new Error(`Normal lesson ${normalDetail.id} not in course tree`);
+  return flat;
+}
+
 export function interceptExercises(page: Page): Promise<LudoExercise[]> {
   return new Promise<LudoExercise[]>((resolve) => {
     page.route("**/api/v1/lessons/*/exercises", async (route) => {
@@ -80,10 +92,6 @@ export function interceptExercises(page: Page): Promise<LudoExercise[]> {
   });
 }
 
-/**
- * Navigates to a lesson from the learn/module page by clicking
- * the path button and popover button.
- */
 export async function navigateToLesson(page: Page, lessonId: string) {
   const pathButton = page.getByTestId(testIds.path.button(lessonId));
   const pathPopoverButton = page.getByTestId(
@@ -94,6 +102,16 @@ export async function navigateToLesson(page: Page, lessonId: string) {
   await pathButton.click();
   await expect(pathPopoverButton).toBeVisible();
   await pathPopoverButton.click();
+}
 
-  await expect(page).toHaveURL(new RegExp(`/lesson/.*${lessonId}`));
+export async function navigateToModule(page: Page, moduleId: string) {
+  const moduleItem = page.getByTestId(testIds.module.item(moduleId)).first();
+  await expect(moduleItem).toBeVisible();
+  await moduleItem.click();
+
+  await page.waitForURL(new RegExp(`/learn/[^/]+/${moduleId}$`));
+}
+
+export function getModuleLessons(mod: FlatModule): FlatLesson[] {
+  return [...mod.lessons].sort((a, b) => a.orderIndex - b.orderIndex);
 }

--- a/apps/web/tests/utils/initialise.ts
+++ b/apps/web/tests/utils/initialise.ts
@@ -1,17 +1,12 @@
 import { type Page, expect } from "@playwright/test";
 import { onboardUser } from "./onboard";
+import { interceptCourseTree, type CourseContext } from "./course";
 
-export async function initialiseUser(page: Page) {
+export async function initialiseUser(page: Page): Promise<CourseContext> {
+  const courseTreePromise = interceptCourseTree(page);
   await onboardUser(page);
-  // const freeButton = page.getByTestId(testIds.subscription.compare("FREE"));
 
-  // await expect(page).toHaveURL(/\/app\/subscription\/comparison$/);
+  await expect(page).toHaveURL(/\/app\/learn\/[^/]+\/[^/]+$/);
 
-  // await expect(freeButton).toBeVisible();
-
-  // await freeButton.click();
-
-  await expect(page).toHaveURL(
-    /\/app\/learn\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f$/,
-  );
+  return courseTreePromise;
 }

--- a/apps/web/tests/utils/lesson.ts
+++ b/apps/web/tests/utils/lesson.ts
@@ -4,17 +4,24 @@ import type { LudoExercise } from "@ludocode/types";
 import {
   interceptExercises,
   navigateToLesson,
-  type CourseContext,
-  getAllLessons,
+  navigateToModule,
+  getModuleLessons,
   getModuleForLesson,
+  getAllLessons,
+  type CourseContext,
 } from "./course";
+import { setMonacoValue } from "./monaco";
 
-async function solveExercise(page: Page, exercise: LudoExercise) {
+
+export function isGuidedLesson(exercises: LudoExercise[]): boolean {
+  return exercises.some((e) => e.interaction?.type === "EXECUTABLE");
+}
+
+async function solveNormalExercise(page: Page, exercise: LudoExercise) {
   const submitButton = page.getByTestId(testIds.lesson.submitButton);
   const submitButtonText = page.getByTestId(testIds.lesson.submitText);
 
   if (!exercise.interaction) {
-    // INFO exercise — just click submit to continue
     await expect(submitButton).toBeVisible();
     await submitButton.click();
     return;
@@ -44,11 +51,57 @@ async function solveExercise(page: Page, exercise: LudoExercise) {
     await submitButton.click();
     return;
   }
+}
 
-  // EXECUTABLE
-  throw new Error(
-    `Unsupported exercise interaction type: ${exercise.interaction.type}`,
-  );
+async function solveGuidedExercise(page: Page, exercise: LudoExercise) {
+  const submitButton = page.getByTestId(testIds.guided.runCodeButton).first();
+  const submitButtonText = page
+    .getByTestId(testIds.guided.runCodeButtonText)
+    .first();
+
+  if (!exercise.interaction || exercise.interaction.type !== "EXECUTABLE") {
+    await expect(submitButton).toBeVisible();
+    await submitButton.click();
+    return;
+  }
+
+  const { solution } = exercise.interaction;
+
+  await setMonacoValue(page, solution);
+
+  await page.waitForTimeout(500);
+
+  await expect(submitButton).toBeVisible();
+  await submitButton.click();
+
+  await expect(submitButtonText).toContainText("CONTINUE", { timeout: 30_000 });
+
+  await page.waitForTimeout(200);
+
+  await submitButton.click();
+}
+
+async function solveGuidedExerciseWithMistake(
+  page: Page,
+  exercise: LudoExercise,
+) {
+  const submitButton = page.getByTestId(testIds.guided.runCodeButton).first();
+  const submitButtonText = page
+    .getByTestId(testIds.guided.runCodeButtonText)
+    .first();
+  const feedbackIncorrect = page.getByTestId(testIds.guided.feedbackIncorrect);
+
+  if (!exercise.interaction || exercise.interaction.type !== "EXECUTABLE") {
+    return;
+  }
+
+  await setMonacoValue(page, "# wrong answer");
+  await page.waitForTimeout(500);
+  await expect(submitButton).toBeVisible();
+  await submitButton.click();
+
+  await expect(submitButtonText).toContainText("RETRY", { timeout: 30_000 });
+  await expect(feedbackIncorrect).toBeVisible();
 }
 
 export async function goToLesson(page: Page, lessonId: string) {
@@ -61,12 +114,14 @@ export async function completeLessonPerfect(
   page: Page,
   exercises: LudoExercise[],
 ) {
-  const normalExercises = exercises.filter(
-    (e) => !e.interaction || e.interaction.type !== "EXECUTABLE",
-  );
-
-  for (const exercise of normalExercises) {
-    await solveExercise(page, exercise);
+  if (isGuidedLesson(exercises)) {
+    for (const exercise of exercises) {
+      await solveGuidedExercise(page, exercise);
+    }
+  } else {
+    for (const exercise of exercises) {
+      await solveNormalExercise(page, exercise);
+    }
   }
 
   await expect(page).toHaveURL(/\/sync\//);
@@ -76,72 +131,120 @@ export async function completeLessonWithMistake(
   page: Page,
   exercises: LudoExercise[],
 ) {
-  const normalExercises = exercises.filter(
-    (e) => !e.interaction || e.interaction.type !== "EXECUTABLE",
-  );
+  if (isGuidedLesson(exercises)) {
+    let madeFirstMistake = false;
 
-  let madeFirstMistake = false;
+    for (const exercise of exercises) {
+      if (!madeFirstMistake && exercise.interaction?.type === "EXECUTABLE") {
+        madeFirstMistake = true;
+        await solveGuidedExerciseWithMistake(page, exercise);
+      }
+      await solveGuidedExercise(page, exercise);
+    }
+  } else {
+    let madeFirstMistake = false;
 
-  for (const exercise of normalExercises) {
-    const submitButton = page.getByTestId(testIds.lesson.submitButton);
-    const submitButtonText = page.getByTestId(testIds.lesson.submitText);
+    for (const exercise of exercises) {
+      const submitButton = page.getByTestId(testIds.lesson.submitButton);
+      const submitButtonText = page.getByTestId(testIds.lesson.submitText);
 
-    if (!madeFirstMistake && exercise.interaction) {
-      madeFirstMistake = true;
+      if (!madeFirstMistake && exercise.interaction) {
+        madeFirstMistake = true;
 
-      if (exercise.interaction.type === "CLOZE") {
-        const correctAnswer = exercise.interaction.blanks[0].correctOptions[0];
-        const wrongOption = exercise.interaction.options.find(
-          (o) => o !== correctAnswer,
-        );
-        if (wrongOption) {
-          const option = page.getByTestId(testIds.exercise.option(wrongOption));
-          await expect(option).toBeVisible();
-          await option.click();
-          await submitButton.click();
-          await expect(submitButtonText).toContainText("TRY AGAIN");
-          await submitButton.click();
-          await expect(submitButtonText).toContainText("CHECK");
-        }
-      } else if (exercise.interaction.type === "SELECT") {
-        const correctAnswer = exercise.interaction.correctValue;
-        const wrongOption = exercise.interaction.items.find(
-          (i) => i !== correctAnswer,
-        );
-        if (wrongOption) {
-          const option = page.getByTestId(
-            testIds.exercise.optionWide(wrongOption),
+        if (exercise.interaction.type === "CLOZE") {
+          const correctAnswer =
+            exercise.interaction.blanks[0].correctOptions[0];
+          const wrongOption = exercise.interaction.options.find(
+            (o) => o !== correctAnswer,
           );
-          await expect(option).toBeVisible();
-          await option.click();
-          await submitButton.click();
-          await expect(submitButtonText).toContainText("TRY AGAIN");
-          await submitButton.click();
-          await expect(submitButtonText).toContainText("CHECK");
+          if (wrongOption) {
+            const option = page.getByTestId(
+              testIds.exercise.option(wrongOption),
+            );
+            await expect(option).toBeVisible();
+            await option.click();
+            await submitButton.click();
+            await expect(submitButtonText).toContainText("TRY AGAIN");
+            await submitButton.click();
+            await expect(submitButtonText).toContainText("CHECK");
+          }
+        } else if (exercise.interaction.type === "SELECT") {
+          const correctAnswer = exercise.interaction.correctValue;
+          const wrongOption = exercise.interaction.items.find(
+            (i) => i !== correctAnswer,
+          );
+          if (wrongOption) {
+            const option = page.getByTestId(
+              testIds.exercise.optionWide(wrongOption),
+            );
+            await expect(option).toBeVisible();
+            await option.click();
+            await submitButton.click();
+            await expect(submitButtonText).toContainText("TRY AGAIN");
+            await submitButton.click();
+            await expect(submitButtonText).toContainText("CHECK");
+          }
         }
       }
-    }
 
-    await solveExercise(page, exercise);
+      await solveNormalExercise(page, exercise);
+    }
   }
 
   await expect(page).toHaveURL(/\/sync\//);
 }
 
+export async function clickThroughCompletion(page: Page) {
+  await expect(page).toHaveURL(/\/completion\//, { timeout: 10_000 });
+
+  const completionButton = page.getByTestId(testIds.completion.button);
+
+  while (!page.url().includes("/learn/")) {
+    await expect(completionButton).toBeVisible();
+    await completionButton.click();
+    await page.waitForURL(/\/(learn|completion)\//);
+  }
+}
+
 export async function completeCourse(page: Page, ctx: CourseContext) {
-  const lessons = getAllLessons(ctx);
+  for (let mi = 0; mi < ctx.modules.length; mi++) {
+    const mod = ctx.modules[mi];
+    const lessons = getModuleLessons(mod);
 
-  for (const lesson of lessons) {
-    const exercises = await goToLesson(page, lesson.id);
-    await completeLessonPerfect(page, exercises);
+    if (mi > 0) {
+      await navigateToModule(page, mod.id);
+    }
 
-    await expect(page).toHaveURL(/\/completion\//);
+    for (const lesson of lessons) {
+      const exercises = await goToLesson(page, lesson.id);
+      await completeLessonPerfect(page, exercises);
+      await clickThroughCompletion(page);
+    }
+  }
+}
 
-    const completionButton = page.getByTestId(testIds.completion.button);
-    while (!(await page.url().includes("/learn/"))) {
-      await expect(completionButton).toBeVisible();
-      await completionButton.click();
-      await page.waitForURL(/\/(learn|completion)\//);
+export async function completeLessonsUpTo(
+  page: Page,
+  ctx: CourseContext,
+  targetLessonId: string,
+) {
+  const allLessons = getAllLessons(ctx);
+  const targetModule = getModuleForLesson(ctx, targetLessonId);
+
+  for (let mi = 0; mi < ctx.modules.length; mi++) {
+    const mod = ctx.modules[mi];
+    const lessons = getModuleLessons(mod);
+
+    if (mi > 0) {
+      await navigateToModule(page, mod.id);
+    }
+
+    for (const lesson of lessons) {
+      if (lesson.id === targetLessonId) return;
+
+      const exercises = await goToLesson(page, lesson.id);
+      await completeLessonPerfect(page, exercises);
+      await clickThroughCompletion(page);
     }
   }
 }

--- a/apps/web/tests/utils/lesson.ts
+++ b/apps/web/tests/utils/lesson.ts
@@ -1,92 +1,147 @@
 import { type Page, expect } from "@playwright/test";
-import {testIds} from "@ludocode/util/test-ids.js"
+import { testIds } from "@ludocode/util/test-ids.js";
+import type { LudoExercise } from "@ludocode/types";
+import {
+  interceptExercises,
+  navigateToLesson,
+  type CourseContext,
+  getAllLessons,
+  getModuleForLesson,
+} from "./course";
 
-export async function goToLesson(page: Page) {
-  const lessonId = "7eeaaddd-2d87-495e-bd40-24cfd9f06b4b";
-  const pathButton = page.getByTestId(testIds.path.button(lessonId));
-  const pathPopoverButton = page.getByTestId(
-    testIds.path.popoverButton(lessonId),
-  );
+async function solveExercise(page: Page, exercise: LudoExercise) {
+  const submitButton = page.getByTestId(testIds.lesson.submitButton);
+  const submitButtonText = page.getByTestId(testIds.lesson.submitText);
 
-  await expect(pathButton).toBeVisible();
-  await pathButton.click();
+  if (!exercise.interaction) {
+    // INFO exercise — just click submit to continue
+    await expect(submitButton).toBeVisible();
+    await submitButton.click();
+    return;
+  }
 
-  await expect(pathPopoverButton).toBeVisible();
+  if (exercise.interaction.type === "CLOZE") {
+    const { blanks } = exercise.interaction;
+    for (const blank of blanks) {
+      const correctAnswer = blank.correctOptions[0];
+      const option = page.getByTestId(testIds.exercise.option(correctAnswer));
+      await expect(option).toBeVisible();
+      await option.click();
+    }
+    await submitButton.click();
+    await expect(submitButtonText).toContainText("CONTINUE");
+    await submitButton.click();
+    return;
+  }
 
-  await pathPopoverButton.click();
+  if (exercise.interaction.type === "SELECT") {
+    const correctAnswer = exercise.interaction.correctValue;
+    const option = page.getByTestId(testIds.exercise.optionWide(correctAnswer));
+    await expect(option).toBeVisible();
+    await option.click();
+    await submitButton.click();
+    await expect(submitButtonText).toContainText("CONTINUE");
+    await submitButton.click();
+    return;
+  }
 
-  await expect(page).toHaveURL(
-    /\/lesson\/.*7eeaaddd-2d87-495e-bd40-24cfd9f06b4b.*/,
+  // EXECUTABLE
+  throw new Error(
+    `Unsupported exercise interaction type: ${exercise.interaction.type}`,
   );
 }
 
-export async function completeLessonWithMistake(page: Page) {
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=1$/,
-  );
-
-  const submitButton = page.getByTestId(testIds.lesson.submitButton);
-  await expect(submitButton).toBeVisible();
-  await submitButton.click();
-
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=2$/,
-  );
-  const submitButtonText = page.getByTestId(testIds.lesson.submitText);
-
-  const secondExerciseCorrectOption = page.getByTestId(
-    testIds.exercise.option("+"),
-  );
-  const secondExerciseDistractor = page.getByTestId(
-    testIds.exercise.option("="),
-  );
-  await expect(secondExerciseDistractor).toBeVisible();
-  await expect(secondExerciseCorrectOption).toBeVisible();
-  await secondExerciseDistractor.click();
-  await submitButton.click();
-  await expect(submitButtonText).toContainText("TRY AGAIN");
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=2$/,
-  );
-  await submitButton.click();
-
-  await expect(submitButtonText).toContainText("CHECK");
-
-  await secondExerciseCorrectOption.click();
-  await submitButton.click();
-  await expect(submitButtonText).toContainText("CONTINUE");
-  await submitButton.click();
-
-  await expect(page).toHaveURL(/\/sync\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b/);
+export async function goToLesson(page: Page, lessonId: string) {
+  const exercisesPromise = interceptExercises(page);
+  await navigateToLesson(page, lessonId);
+  return exercisesPromise;
 }
 
-export async function completeLessonPerfect(page: Page) {
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=1$/,
+export async function completeLessonPerfect(
+  page: Page,
+  exercises: LudoExercise[],
+) {
+  const normalExercises = exercises.filter(
+    (e) => !e.interaction || e.interaction.type !== "EXECUTABLE",
   );
 
-  const submitButton = page.getByTestId(testIds.lesson.submitButton);
-  await expect(submitButton).toBeVisible();
-  await submitButton.click();
+  for (const exercise of normalExercises) {
+    await solveExercise(page, exercise);
+  }
 
-  await expect(page).toHaveURL(
-    /\/lesson\/75975805-3f02-43c2-9106-c990d944dfd2\/a99d4abd-895f-4a4b-b4ea-570fac609f6f\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b\?exercise=2$/,
+  await expect(page).toHaveURL(/\/sync\//);
+}
+
+export async function completeLessonWithMistake(
+  page: Page,
+  exercises: LudoExercise[],
+) {
+  const normalExercises = exercises.filter(
+    (e) => !e.interaction || e.interaction.type !== "EXECUTABLE",
   );
 
-  const submitButtonText = page.getByTestId(testIds.lesson.submitText);
+  let madeFirstMistake = false;
 
-  const secondExerciseCorrectOption = page.getByTestId(
-    testIds.exercise.option("+"),
-  );
-  const secondExerciseDistractor = page.getByTestId(
-    testIds.exercise.option("="),
-  );
-  await expect(secondExerciseDistractor).toBeVisible();
-  await expect(secondExerciseCorrectOption).toBeVisible();
-  await secondExerciseCorrectOption.click();
-  await submitButton.click();
-  await expect(submitButtonText).toContainText("CONTINUE");
-  await submitButton.click();
+  for (const exercise of normalExercises) {
+    const submitButton = page.getByTestId(testIds.lesson.submitButton);
+    const submitButtonText = page.getByTestId(testIds.lesson.submitText);
 
-  await expect(page).toHaveURL(/\/sync\/7eeaaddd-2d87-495e-bd40-24cfd9f06b4b/);
+    if (!madeFirstMistake && exercise.interaction) {
+      madeFirstMistake = true;
+
+      if (exercise.interaction.type === "CLOZE") {
+        const correctAnswer = exercise.interaction.blanks[0].correctOptions[0];
+        const wrongOption = exercise.interaction.options.find(
+          (o) => o !== correctAnswer,
+        );
+        if (wrongOption) {
+          const option = page.getByTestId(testIds.exercise.option(wrongOption));
+          await expect(option).toBeVisible();
+          await option.click();
+          await submitButton.click();
+          await expect(submitButtonText).toContainText("TRY AGAIN");
+          await submitButton.click();
+          await expect(submitButtonText).toContainText("CHECK");
+        }
+      } else if (exercise.interaction.type === "SELECT") {
+        const correctAnswer = exercise.interaction.correctValue;
+        const wrongOption = exercise.interaction.items.find(
+          (i) => i !== correctAnswer,
+        );
+        if (wrongOption) {
+          const option = page.getByTestId(
+            testIds.exercise.optionWide(wrongOption),
+          );
+          await expect(option).toBeVisible();
+          await option.click();
+          await submitButton.click();
+          await expect(submitButtonText).toContainText("TRY AGAIN");
+          await submitButton.click();
+          await expect(submitButtonText).toContainText("CHECK");
+        }
+      }
+    }
+
+    await solveExercise(page, exercise);
+  }
+
+  await expect(page).toHaveURL(/\/sync\//);
+}
+
+export async function completeCourse(page: Page, ctx: CourseContext) {
+  const lessons = getAllLessons(ctx);
+
+  for (const lesson of lessons) {
+    const exercises = await goToLesson(page, lesson.id);
+    await completeLessonPerfect(page, exercises);
+
+    await expect(page).toHaveURL(/\/completion\//);
+
+    const completionButton = page.getByTestId(testIds.completion.button);
+    while (!(await page.url().includes("/learn/"))) {
+      await expect(completionButton).toBeVisible();
+      await completionButton.click();
+      await page.waitForURL(/\/(learn|completion)\//);
+    }
+  }
 }

--- a/packages/design-system/widgets/ludo-list.tsx
+++ b/packages/design-system/widgets/ludo-list.tsx
@@ -37,6 +37,7 @@ type ItemProps = {
   isActive?: boolean;
   isComplete?: boolean;
   progress?: ProgressSummaryProps;
+  dataTestId?: string;
 };
 
 function Item({
@@ -46,11 +47,13 @@ function Item({
   onClick,
   isActive,
   isComplete,
+  dataTestId,
 }: ItemProps) {
   const Component = onClick ? "button" : "div";
 
   return (
     <Component
+      data-testid={dataTestId}
       {...(onClick && { type: "button", onClick })}
       className={cn(
         "w-full flex relative items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-150",

--- a/packages/util/test-ids.ts
+++ b/packages/util/test-ids.ts
@@ -5,95 +5,104 @@
  */
 
 export const testIds = {
-    // ── Auth ──────────────────────────────────────────────
-    auth: {
-        registerTos: "register-tos",
-    },
+  // ── Auth ──────────────────────────────────────────────
+  auth: {
+    registerTos: "register-tos",
+  },
 
-    // ── Onboarding ────────────────────────────────────────
-    onboarding: {
-        usernameInput: "username-input",
-        career: (choice: string) => `onb-career-${choice}`,
-        course: (id: string) => `onb-course-${id}`,
-        experience: (value: boolean) => `onb-exp-${value}`,
-    },
+  // ── Onboarding ────────────────────────────────────────
+  onboarding: {
+    usernameInput: "username-input",
+    career: (choice: string) => `onb-career-${choice}`,
+    course: (id: string) => `onb-course-${id}`,
+    experience: (value: boolean) => `onb-exp-${value}`,
+  },
 
-    // ── Navigation ────────────────────────────────────────
-    nav: {
-        button: (prefix: string, name: string) => `nav-button-${prefix}-${name}`,
-    },
+  // ── Navigation ────────────────────────────────────────
+  nav: {
+    button: (prefix: string, name: string) => `nav-button-${prefix}-${name}`,
+  },
 
-    // ── Module path ───────────────────────────────────────
-    path: {
-        button: (lessonId: string) => `path-button-${lessonId}`,
-        popoverButton: (lessonId: string) => `path-popover-button-${lessonId}`,
-    },
+  // ── Module navigation ──────────────────────────────────
+  module: {
+    item: (moduleId: string) => `module-item-${moduleId}`,
+    nextButton: "module-next-button",
+  },
 
-    // ── Lesson ────────────────────────────────────────────
-    lesson: {
-        submitButton: "lesson-submit-button",
-        submitText: "lesson-submit-text",
-        backButton: "lesson-back-button",
-        audioToggleButton: "lesson-audio-toggle-button",
-        aiButton: "lesson-ai-button",
-        feedbackButton: "exercise-feedback-button",
-        discussionButton: "exercise-discussion-button",
-    },
+  // ── Module path ───────────────────────────────────────
+  path: {
+    button: (lessonId: string) => `path-button-${lessonId}`,
+    popoverButton: (lessonId: string) => `path-popover-button-${lessonId}`,
+  },
 
-    // ── Guided lesson ─────────────────────────────────────
-    guided: {
-        runCodeButton: "guided-run-code-button",
-        asideLeft: "guided-project-aside-left",
-    },
+  // ── Lesson ────────────────────────────────────────────
+  lesson: {
+    submitButton: "lesson-submit-button",
+    submitText: "lesson-submit-text",
+    backButton: "lesson-back-button",
+    audioToggleButton: "lesson-audio-toggle-button",
+    aiButton: "lesson-ai-button",
+    feedbackButton: "exercise-feedback-button",
+    discussionButton: "exercise-discussion-button",
+  },
 
-    // ── Exercise options ──────────────────────────────────
-    exercise: {
-        option: (content: string) => `exercise-option-${content}`,
-        optionWide: (content: string) => `exercise-option-wide-${content}`,
-    },
+  // ── Guided lesson ─────────────────────────────────────
+  guided: {
+    runCodeButton: "guided-run-code-button",
+    runCodeButtonText: "guided-run-code-button-text",
+    asideLeft: "guided-project-aside-left",
+    feedbackCorrect: "guided-feedback-correct",
+    feedbackIncorrect: "guided-feedback-incorrect",
+  },
 
-    // ── Completion ────────────────────────────────────────
-    completion: {
-        button: "completion-button",
-        coins: "completion-coins",
-        accuracy: "completion-accuracy",
-        xp: "completion-xp",
-        streakText: "streak-complete-text",
-        courseCompleteHeader: "course-complete-header",
-        courseCompleteCongratulation: "course-complete-congratulation",
-        courseCompleteBadgeText: "course-complete-badge-text",
-    },
+  // ── Exercise options ──────────────────────────────────
+  exercise: {
+    option: (content: string) => `exercise-option-${content}`,
+    optionWide: (content: string) => `exercise-option-wide-${content}`,
+  },
 
-    // ── Project hub ───────────────────────────────────────
-    projectHub: {
-        card: "project-hub-card",
-        limits: "project-limits",
-        createTemplate: (key: string) => `create-project-template-${key}`,
-        upgradeLimitButton: "upgrade-project-limit-button",
-    },
+  // ── Completion ────────────────────────────────────────
+  completion: {
+    button: "completion-button",
+    coins: "completion-coins",
+    accuracy: "completion-accuracy",
+    xp: "completion-xp",
+    streakText: "streak-complete-text",
+    courseCompleteHeader: "course-complete-header",
+    courseCompleteCongratulation: "course-complete-congratulation",
+    courseCompleteBadgeText: "course-complete-badge-text",
+  },
 
-    // ── Project workbench ─────────────────────────────────
-    project: {
-        asideLeft: "project-aside-left",
-        runner: "project-runner",
-        clearOutput: "clear-output-icon",
-        livePreview: "live-preview-frame",
-        stdinInput: "runner-stdin-input",
-        runCodeButton: "run-code-button",
-        openFilePopover: "open-file-popover-icon",
-        newFileButton: "new-file-button",
-        newFileButtonLang: (lang: string) => `new-file-button-${lang}`,
-        treeFile: (path: string) => `tree-file-${path}`,
-        cloudIcon: (status: string) => `project-cloud-icon-${status}`,
-    },
+  // ── Project hub ───────────────────────────────────────
+  projectHub: {
+    card: "project-hub-card",
+    limits: "project-limits",
+    createTemplate: (key: string) => `create-project-template-${key}`,
+    upgradeLimitButton: "upgrade-project-limit-button",
+  },
 
-    // ── Subscription ──────────────────────────────────────
-    subscription: {
-        compare: (tier: string) => `sub-compare-${tier}`,
-    },
+  // ── Project workbench ─────────────────────────────────
+  project: {
+    asideLeft: "project-aside-left",
+    runner: "project-runner",
+    clearOutput: "clear-output-icon",
+    livePreview: "live-preview-frame",
+    stdinInput: "runner-stdin-input",
+    runCodeButton: "run-code-button",
+    openFilePopover: "open-file-popover-icon",
+    newFileButton: "new-file-button",
+    newFileButtonLang: (lang: string) => `new-file-button-${lang}`,
+    treeFile: (path: string) => `tree-file-${path}`,
+    cloudIcon: (status: string) => `project-cloud-icon-${status}`,
+  },
 
-    // ── Design system primitives ──────────────────────────
-    select: {
-        trigger: "select-trigger",
-    },
+  // ── Subscription ──────────────────────────────────────
+  subscription: {
+    compare: (tier: string) => `sub-compare-${tier}`,
+  },
+
+  // ── Design system primitives ──────────────────────────
+  select: {
+    trigger: "select-trigger",
+  },
 } as const;


### PR DESCRIPTION
## Summary
This PR adds lesson completion utilities for playwright tests such as `completeLessonsUpTo` which completes all lessons up to a chosen lesson in a path, or `completeLessonWithMistake` which completes a selected lesson with a mistake.

This PR also adds tests for guided lessons

## Why
This helps with testing behaviors and not worrying about hardcoded ids. It allows adding new lessons to the e2e seed data without rewriting each test all the time. 

## Changes
- Added lesson / course completion utilities in `lesson.ts` of the tests folder
- Added `guidedLesson.spec` for testing guided lessons
- Added additional test ids for guided lessons and module navigation