### PR TITLE
feat: Add guest login

### DIFF
--- a/apps/web/src/constants/ludoNavigation.tsx
+++ b/apps/web/src/constants/ludoNavigation.tsx
@@ -57,6 +57,7 @@ export const ludoNavigation = {
       to: authRegisterRoute.to,
       replace: replace,
     }),
+    guest: (replace = true) => ({ to: "/auth/guest", replace: replace }),
   },
 
   app: {

--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -41,6 +41,15 @@ export function LoginPage() {
                   Register here
                 </span>{" "}
               </p>
+              <p>
+                Just curious?{" "}
+                <span
+                  onClick={() => router.navigate(ludoNavigation.auth.guest())}
+                  className="hover:cursor-pointer font-bold underline"
+                >
+                  Use a guest account
+                </span>{" "}
+              </p>
               {/* <p>
                 Forgot your password?{" "}
                 <span className="font-bold underline">Reset your password</span>

--- a/apps/web/src/features/auth/RegistrationPage.tsx
+++ b/apps/web/src/features/auth/RegistrationPage.tsx
@@ -40,6 +40,15 @@ export function RegistrationPage() {
                   Sign in here
                 </span>{" "}
               </p>
+              <p>
+                Just curious?{" "}
+                <span
+                  onClick={() => router.navigate(ludoNavigation.auth.guest())}
+                  className="hover:cursor-pointer font-bold underline"
+                >
+                  Use a guest account
+                </span>{" "}
+              </p>
               {/* <p>
                 Forgot your password?{" "}
                 <span className="font-bold underline">Reset your password</span>

--- a/apps/web/src/features/landing/components/LandingHero.tsx
+++ b/apps/web/src/features/landing/components/LandingHero.tsx
@@ -29,6 +29,21 @@ export function LandingHero() {
           Get Started
         </LudoButton>
         <LudoButton
+          variant="alt"
+          className="flex-1 h-full"
+          onClick={() => {
+            track({
+              event: "SIGNUP_CLICK",
+              properties: { source: "landing_cta_guest" },
+            });
+            router.navigate(ludoNavigation.auth.guest(false));
+          }}
+        >
+          Try as Guest
+        </LudoButton>
+      </div>
+      <div className="flex gap-4 mt-4 h-10 w-full">
+        <LudoButton
           variant="default"
           className="flex-1 h-full"
           onClick={() => {

--- a/apps/web/src/queries/mutations/guestLogin.ts
+++ b/apps/web/src/queries/mutations/guestLogin.ts
@@ -1,0 +1,15 @@
+import { api } from "@/constants/api/api.ts";
+import { finalizeLoginResponse } from "@/queries/mutations/useFinalizeLogin.tsx";
+import { ludoPost } from "@ludocode/api/fetcher.ts";
+import type { LoginUserResponse } from "@ludocode/types";
+import type { QueryClient } from "@tanstack/react-query";
+
+export async function loginAsGuest(queryClient: QueryClient) {
+  const loginResponse = await ludoPost<LoginUserResponse>(
+    api.auth.guest,
+    {},
+    true,
+  );
+
+  return finalizeLoginResponse(loginResponse, queryClient);
+}

--- a/apps/web/src/queries/mutations/guestLogin.ts
+++ b/apps/web/src/queries/mutations/guestLogin.ts
@@ -1,13 +1,49 @@
 import { api } from "@/constants/api/api.ts";
+import { qo } from "@/queries/definitions/queries.ts";
 import { finalizeLoginResponse } from "@/queries/mutations/useFinalizeLogin.tsx";
 import { ludoPost } from "@ludocode/api/fetcher.ts";
-import type { LoginUserResponse } from "@ludocode/types";
+import type { LoginUserResponse, OnboardingSubmission } from "@ludocode/types";
 import type { QueryClient } from "@tanstack/react-query";
 
+async function createGuestOnboardingData(
+  queryClient: QueryClient,
+): Promise<OnboardingSubmission> {
+  const [courses, careers] = await Promise.all([
+    queryClient.ensureQueryData(qo.allCourses()),
+    queryClient.ensureQueryData(qo.allCareers()),
+  ]);
+
+  const publishedCourses = courses.filter(
+    (course) => course.courseStatus === "PUBLISHED",
+  );
+  const eligibleCourses =
+    publishedCourses.length > 0 ? publishedCourses : courses;
+  const career =
+    careers.find((career) =>
+      eligibleCourses.some((course) => course.id === career.defaultCourseId),
+    ) ?? careers[0];
+  const course =
+    eligibleCourses.find((course) => course.id === career?.defaultCourseId) ??
+    eligibleCourses[0];
+
+  if (!career || !course) {
+    throw new Error("Cannot create guest account without onboarding options.");
+  }
+
+  return {
+    selectedUsername: `guest`,
+    chosenPath: career.choice,
+    chosenCourse: course.id,
+    hasProgrammingExperience: false,
+  };
+}
+
 export async function loginAsGuest(queryClient: QueryClient) {
-  const loginResponse = await ludoPost<LoginUserResponse>(
+  const onboardingData = await createGuestOnboardingData(queryClient);
+
+  const loginResponse = await ludoPost<LoginUserResponse, OnboardingSubmission>(
     api.auth.guest,
-    {},
+    onboardingData,
     true,
   );
 

--- a/apps/web/src/queries/mutations/useFinalizeLogin.tsx
+++ b/apps/web/src/queries/mutations/useFinalizeLogin.tsx
@@ -1,50 +1,65 @@
 import { api } from "@/constants/api/api.ts";
 import { ludoPost } from "@ludocode/api/fetcher.ts";
 import type { LoginUserResponse } from "@ludocode/types";
-import { useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { qk } from "@/queries/definitions/qk.ts";
 import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
 import { qo } from "@/queries/definitions/queries.ts";
 
-export function useFinalizeLogin() {
+export async function finalizeLoginResponse(
+  { user, userCoins, userStreak, userXp }: LoginUserResponse,
+  queryClient: QueryClient,
+) {
+  queryClient.setQueryData(qk.user(user.id), user);
+  queryClient.setQueryData(qk.currentUser(), user);
+  queryClient.setQueryData(qk.userCoins(user.id), userCoins);
+  queryClient.setQueryData(qk.xp(user.id), userXp);
+  queryClient.setQueryData(qk.streak(user.id), userStreak);
+
+  if (!user.hasOnboarded) {
+    queryClient.setQueryData(qk.onboardingDraft(), {
+      username: user.displayName?.trim() || undefined,
+    });
+
+    return ludoNavigation.onboarding.start();
+  }
+
+  const currentCourseId = await queryClient.ensureQueryData(
+    qo.currentCourseId(),
+  );
+  const currentCourseProgress = await queryClient.ensureQueryData(
+    qo.courseProgress(currentCourseId),
+  );
+
+  return ludoNavigation.hub.module.toModule(
+    currentCourseProgress.courseId,
+    currentCourseProgress.moduleId,
+    true,
+  );
+}
+
+export function useLoginResponseHandler() {
   const queryClient = useQueryClient();
   const router = useRouter();
 
+  return async (loginResponse: LoginUserResponse) => {
+    const navigation = await finalizeLoginResponse(loginResponse, queryClient);
+    router.navigate(navigation);
+  };
+}
+
+export function useFinalizeLogin() {
+  const handleLoginResponse = useLoginResponseHandler();
+
   return async (idToken: string) => {
-    const { user, userCoins, userStreak, userXp }: LoginUserResponse = await ludoPost(
+    const loginResponse: LoginUserResponse = await ludoPost(
       api.auth.firebase,
       {},
       true,
       { Authorization: `Bearer ${idToken}` },
     );
 
-    queryClient.setQueryData(qk.user(user.id), user);
-    queryClient.setQueryData(qk.currentUser(), user);
-    queryClient.setQueryData(qk.userCoins(user.id), userCoins);
-    queryClient.setQueryData(qk.xp(user.id), userXp)
-    queryClient.setQueryData(qk.streak(user.id), userStreak);
-
-    if (!user.hasOnboarded) {
-      queryClient.setQueryData(qk.onboardingDraft(), {
-        username: user.displayName?.trim() || undefined,
-      });
-
-      router.navigate(ludoNavigation.onboarding.start());
-    } else {
-      const currentCourseId = await queryClient.ensureQueryData(
-        qo.currentCourseId(),
-      );
-      const currentCourseProgress = await queryClient.ensureQueryData(
-        qo.courseProgress(currentCourseId),
-      );
-      router.navigate(
-        ludoNavigation.hub.module.toModule(
-          currentCourseProgress.courseId,
-          currentCourseProgress.moduleId,
-          true,
-        ),
-      );
-    }
+    await handleLoginResponse(loginResponse);
   };
 }

--- a/apps/web/src/queries/mutations/useGuestLogin.tsx
+++ b/apps/web/src/queries/mutations/useGuestLogin.tsx
@@ -1,0 +1,26 @@
+import { loginAsGuest } from "@/queries/mutations/guestLogin.ts";
+import { errorToast } from "@ludocode/design-system/primitives/toast.tsx";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
+import { useRef } from "react";
+
+export function useGuestLogin() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const isRunningRef = useRef(false);
+
+  return async () => {
+    if (isRunningRef.current) return;
+
+    try {
+      isRunningRef.current = true;
+
+      const navigation = await loginAsGuest(queryClient);
+      router.navigate(navigation);
+    } catch {
+      errorToast("Guest login failed. Please try again.");
+    } finally {
+      isRunningRef.current = false;
+    }
+  };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as ResourcesIndexRouteImport } from './routes/_resources/index'
 import { Route as AuthRegisterRouteImport } from './routes/auth/register'
 import { Route as AuthLoginRouteImport } from './routes/auth/login'
+import { Route as AuthGuestRouteImport } from './routes/auth/guest'
 import { Route as AppSubscriptionRouteRouteImport } from './routes/app/subscription/route'
 import { Route as AppHubRouteRouteImport } from './routes/app/_hub/route'
 import { Route as ResourcesLegalRouteRouteImport } from './routes/_resources/legal/route'
@@ -77,6 +78,11 @@ const AuthRegisterRoute = AuthRegisterRouteImport.update({
 const AuthLoginRoute = AuthLoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthGuestRoute = AuthGuestRouteImport.update({
+  id: '/guest',
+  path: '/guest',
   getParentRoute: () => AuthRouteRoute,
 } as any)
 const AppSubscriptionRouteRoute = AppSubscriptionRouteRouteImport.update({
@@ -234,6 +240,7 @@ export interface FileRoutesByFullPath {
   '/auth': typeof AuthRouteRouteWithChildren
   '/legal': typeof ResourcesLegalRouteRouteWithChildren
   '/app/subscription': typeof AppSubscriptionSubscribedguardRouteRouteWithChildren
+  '/auth/guest': typeof AuthGuestRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
   '/': typeof ResourcesIndexRoute
@@ -268,6 +275,7 @@ export interface FileRoutesByTo {
   '/legal': typeof ResourcesLegalRouteRouteWithChildren
   '/app': typeof AppIndexRoute
   '/app/subscription': typeof AppSubscriptionSubscribedguardRouteRouteWithChildren
+  '/auth/guest': typeof AuthGuestRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
   '/': typeof ResourcesIndexRoute
@@ -302,6 +310,7 @@ export interface FileRoutesById {
   '/_resources/legal': typeof ResourcesLegalRouteRouteWithChildren
   '/app/_hub': typeof AppHubRouteRouteWithChildren
   '/app/subscription': typeof AppSubscriptionRouteRouteWithChildren
+  '/auth/guest': typeof AuthGuestRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
   '/_resources/': typeof ResourcesIndexRoute
@@ -339,6 +348,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/legal'
     | '/app/subscription'
+    | '/auth/guest'
     | '/auth/login'
     | '/auth/register'
     | '/'
@@ -373,6 +383,7 @@ export interface FileRouteTypes {
     | '/legal'
     | '/app'
     | '/app/subscription'
+    | '/auth/guest'
     | '/auth/login'
     | '/auth/register'
     | '/'
@@ -406,6 +417,7 @@ export interface FileRouteTypes {
     | '/_resources/legal'
     | '/app/_hub'
     | '/app/subscription'
+    | '/auth/guest'
     | '/auth/login'
     | '/auth/register'
     | '/_resources/'
@@ -493,6 +505,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/auth/login'
       preLoaderRoute: typeof AuthLoginRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/auth/guest': {
+      id: '/auth/guest'
+      path: '/guest'
+      fullPath: '/auth/guest'
+      preLoaderRoute: typeof AuthGuestRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/app/subscription': {
@@ -839,11 +858,13 @@ const AppRouteRouteWithChildren = AppRouteRoute._addFileChildren(
 )
 
 interface AuthRouteRouteChildren {
+  AuthGuestRoute: typeof AuthGuestRoute
   AuthLoginRoute: typeof AuthLoginRoute
   AuthRegisterRoute: typeof AuthRegisterRoute
 }
 
 const AuthRouteRouteChildren: AuthRouteRouteChildren = {
+  AuthGuestRoute: AuthGuestRoute,
   AuthLoginRoute: AuthLoginRoute,
   AuthRegisterRoute: AuthRegisterRoute,
 }

--- a/apps/web/src/routes/auth/guest.tsx
+++ b/apps/web/src/routes/auth/guest.tsx
@@ -1,0 +1,11 @@
+import { loginAsGuest } from "@/queries/mutations/guestLogin.ts";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/auth/guest")({
+  beforeLoad: async ({ context }) => {
+    const navigation = await loginAsGuest(context.queryClient);
+
+    throw redirect(navigation);
+  },
+  component: () => null,
+});

--- a/apps/web/tests/guestLogin.spec.ts
+++ b/apps/web/tests/guestLogin.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test, type Page } from "@playwright/test";
+import { testIds } from "@ludocode/util/test-ids.js";
+
+async function expectGuestLoginComplete(page: Page) {
+  await expect(page).toHaveURL(/\/app\/learn\/[^/]+\/[^/]+$/, {
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByTestId(testIds.nav.button("header", "Learn")),
+  ).toBeVisible();
+  await expect(page.getByTestId(testIds.onboarding.usernameInput)).toBeHidden();
+}
+
+test.describe("guest login", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("user can log in as guest from the landing page CTA", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Try as Guest" }).click();
+
+    await expectGuestLoginComplete(page);
+  });
+
+  test("user can visit the guest auth route directly", async ({ page }) => {
+    await page.goto("/auth/guest");
+
+    await expectGuestLoginComplete(page);
+  });
+
+  test("user can log in as guest from the registration page link", async ({
+    page,
+  }) => {
+    await page.goto("/auth/register");
+    await page.getByText("Use a guest account").click();
+
+    await expectGuestLoginComplete(page);
+  });
+});

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -34,6 +34,7 @@ export function createApiPaths({
     auth: {
       base: `${BASE}/auth`,
       firebase: `${BASE}/auth/firebase`,
+      guest: `${BASE}/auth/guest`,
       checkAdmin: `${ADMIN_BASE}/auth/check`,
       me: `${BASE}/auth/me`,
       logout: `${BASE}/auth/logout`,


### PR DESCRIPTION
## Summary
This PR adds an option to log in as a guest, in which the user gets an already onboarded one time use account that they can use while the token is valid. The idea is to make trying the app easier for people who don't want to create an account and go through the onboarding. 

## Changes
- Added `auth.guest` endpoint to `api-paths.ts`
- Added `useGuestLogin` hook for handling guest login
- Added `guestLogin` mutation which appends a pre-fiilled onboarding submission to auto-onboard the user
- Added `/auth/guest` route that auto logs in the user as a guest user
- Added guest login auxiliary actions at the bottom of register & login pages
- Added a "Try as guest" CTA button in the landing page hero
- Added `guestLogin.spec` with 3 E2E tests for testing the guest login functionality

## Testing
Three playwright E2E tests in `guestLogin.spec` which test login directly through route, through landing page CTA, and through registration page auxiliary link.

## Keywords

Rabbit