### PR TITLE
feat: Add leaderboard header

### DIFF
--- a/apps/web/src/features/leaderboard/hub/LeaderboardPage.tsx
+++ b/apps/web/src/features/leaderboard/hub/LeaderboardPage.tsx
@@ -11,10 +11,9 @@ import { ludoNavigation } from "@/constants/ludoNavigation";
 import { router } from "@/main";
 import type { LudoUser } from "@ludocode/types";
 import { useLogout } from "@/queries/mutations/useLogout";
+import { LeaderboardPeriodHeader } from "./components/LeaderboardPeriodHeader";
 
-type LeaderboardPageProps = {};
-
-export function LeaderboardPage({}: LeaderboardPageProps) {
+export function LeaderboardPage() {
   const { data: currentUser } = useSuspenseQuery(qo.currentUser());
   const { data: leaderboard } = useSuspenseQuery(qo.weeklyLeaderboard());
   const leaderboardUsers = leaderboard.leaderboardUsers;
@@ -33,6 +32,10 @@ export function LeaderboardPage({}: LeaderboardPageProps) {
     <div className="layout-grid grid-rows-1 col-span-full h-full min-h-0 overflow-hidden px-8 py-6 text-ludo-white lg:px-0">
       <div className="col-span-1 hidden lg:block" />
       <div className="col-span-full mx-auto flex min-h-0 min-w-0 w-full max-w-2xl flex-col justify-start gap-6 overflow-hidden lg:col-span-10">
+        <LeaderboardPeriodHeader
+          startDate={leaderboard.startDate}
+          endDate={leaderboard.endDate}
+        />
         <LeaderboardPodium
           currentUserId={currentUser.id}
           topUsers={podiumUsers}

--- a/apps/web/src/features/leaderboard/hub/LeaderboardPage.tsx
+++ b/apps/web/src/features/leaderboard/hub/LeaderboardPage.tsx
@@ -29,9 +29,9 @@ export function LeaderboardPage() {
   }
 
   return (
-    <div className="layout-grid grid-rows-1 col-span-full h-full min-h-0 overflow-hidden px-8 py-6 text-ludo-white lg:px-0">
+    <div className="layout-grid grid-rows-1 col-span-full h-full min-h-0 overflow-hidden px-4 py-3 text-ludo-white sm:px-8 lg:px-0 lg:py-6">
       <div className="col-span-1 hidden lg:block" />
-      <div className="col-span-full mx-auto flex min-h-0 min-w-0 w-full max-w-2xl flex-col justify-start gap-6 overflow-hidden lg:col-span-10">
+      <div className="col-span-full mx-auto flex min-h-0 min-w-0 w-full max-w-2xl flex-col justify-start gap-3 overflow-hidden lg:col-span-10 lg:gap-6">
         <LeaderboardPeriodHeader
           startDate={leaderboard.startDate}
           endDate={leaderboard.endDate}

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
@@ -1,9 +1,5 @@
 import { Progress } from "@ludocode/external/ui/progress";
-import {
-  formatShortDate,
-  getDateRangeProgress,
-  toDate,
-} from "@ludocode/util/date/dateUtils";
+import { formatShortDateRange, getDateRangeProgress, toDate } from "@ludocode/util/date/dateUtils";
 import { CalendarDays } from "lucide-react";
 
 type LeaderboardPeriodHeaderProps = {
@@ -20,32 +16,28 @@ export function LeaderboardPeriodHeader({
   const progress = getDateRangeProgress(start, end);
 
   return (
-    <section className="shrink-0 rounded-xl border border-ludo-border bg-ludo-surface-dim p-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <section className="shrink-0 rounded-xl border border-ludo-border bg-ludo-surface-dim p-3 lg:p-4">
+      <div className="flex flex-col gap-1.5 lg:flex-row lg:items-center lg:justify-between lg:gap-3">
         <div>
-          <p className="text-xs font-bold uppercase tracking-wider text-ludo-accent-muted">
-            Current round 
+          <p className="hidden text-xs font-bold uppercase tracking-wider text-ludo-accent-muted lg:block">
+            Current round
           </p>
           <h1
             id="leaderboard-period-title"
-            className="text-xl font-bold text-ludo-white-bright"
+            className="text-lg font-bold text-ludo-white-bright lg:text-xl"
           >
             Weekly Leaderboard
           </h1>
         </div>
 
-        <div className="flex items-center gap-2 text-xs text-ludo-white-dim">
-          <CalendarDays className="size-4 text-ludo-accent-muted" />
-          <span>
-            <time dateTime={start.toISOString()}>{formatShortDate(start)}</time>
-            <span> — </span>
-            <time dateTime={end.toISOString()}>{formatShortDate(end)}</time>
-          </span>
+        <div className="flex items-center gap-1.5 text-[11px] text-ludo-white-dim lg:gap-2 lg:text-xs">
+          <CalendarDays className="size-3.5 text-ludo-accent-muted lg:size-4" />
+          <span>{formatShortDateRange(start, end)}</span>
         </div>
       </div>
 
-      <div className="mt-4">
-        <div className="mb-1.5 flex justify-between text-xs font-medium text-ludo-white-dim">
+      <div className="mt-2.5 lg:mt-4">
+        <div className="mb-1 flex justify-between text-[11px] font-medium text-ludo-white-dim lg:mb-1.5 lg:text-xs">
           <span>Week progress</span>
           <span className="text-ludo-accent-muted tabular-nums">
             {Math.round(progress)}%

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
@@ -1,5 +1,9 @@
 import { Progress } from "@ludocode/external/ui/progress";
-import { formatShortDateRange, getDateRangeProgress, toDate } from "@ludocode/util/date/dateUtils";
+import {
+  formatShortDateRange,
+  getDateRangeProgress,
+  toDate,
+} from "@ludocode/util/date/dateUtils";
 import { CalendarDays } from "lucide-react";
 
 type LeaderboardPeriodHeaderProps = {
@@ -18,31 +22,16 @@ export function LeaderboardPeriodHeader({
   return (
     <section className="shrink-0 rounded-xl border border-ludo-border bg-ludo-surface-dim p-3 lg:p-4">
       <div className="flex flex-col gap-1.5 lg:flex-row lg:items-center lg:justify-between lg:gap-3">
-        <div>
-          <p className="hidden text-xs font-bold uppercase tracking-wider text-ludo-accent-muted lg:block">
-            Current round
-          </p>
-          <h1
-            id="leaderboard-period-title"
-            className="text-lg font-bold text-ludo-white-bright lg:text-xl"
-          >
-            Weekly Leaderboard
-          </h1>
-        </div>
-
-        <div className="flex items-center gap-1.5 text-[11px] text-ludo-white-dim lg:gap-2 lg:text-xs">
+        <h1 className="text-lg font-bold text-ludo-white-bright lg:text-xl">
+          Weekly Leaderboard
+        </h1>
+        <div className="flex items-center gap-1.5 text-xs text-ludo-white-dim lg:gap-2 lg:text-xs">
           <CalendarDays className="size-3.5 text-ludo-accent-muted lg:size-4" />
           <span>{formatShortDateRange(start, end)}</span>
         </div>
       </div>
 
       <div className="mt-2.5 lg:mt-4">
-        <div className="mb-1 flex justify-between text-[11px] font-medium text-ludo-white-dim lg:mb-1.5 lg:text-xs">
-          <span>Week progress</span>
-          <span className="text-ludo-accent-muted tabular-nums">
-            {Math.round(progress)}%
-          </span>
-        </div>
         <Progress
           className="h-2 border border-ludo-border bg-ludo-background/60"
           value={progress}

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
@@ -1,0 +1,61 @@
+import { Progress } from "@ludocode/external/ui/progress";
+import {
+  formatShortDate,
+  getDateRangeProgress,
+  toDate,
+} from "@ludocode/util/date/dateUtils";
+import { CalendarDays } from "lucide-react";
+
+type LeaderboardPeriodHeaderProps = {
+  startDate: number;
+  endDate: number;
+};
+
+export function LeaderboardPeriodHeader({
+  startDate,
+  endDate,
+}: LeaderboardPeriodHeaderProps) {
+  const start = toDate(startDate);
+  const end = toDate(endDate);
+  const progress = getDateRangeProgress(start, end);
+
+  return (
+    <section className="shrink-0 rounded-xl border border-ludo-border bg-ludo-surface-dim p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-ludo-accent-muted">
+            Current round 
+          </p>
+          <h1
+            id="leaderboard-period-title"
+            className="text-xl font-bold text-ludo-white-bright"
+          >
+            Weekly Leaderboard
+          </h1>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-ludo-white-dim">
+          <CalendarDays className="size-4 text-ludo-accent-muted" />
+          <span>
+            <time dateTime={start.toISOString()}>{formatShortDate(start)}</time>
+            <span> — </span>
+            <time dateTime={end.toISOString()}>{formatShortDate(end)}</time>
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="mb-1.5 flex justify-between text-xs font-medium text-ludo-white-dim">
+          <span>Week progress</span>
+          <span className="text-ludo-accent-muted tabular-nums">
+            {Math.round(progress)}%
+          </span>
+        </div>
+        <Progress
+          className="h-2 border border-ludo-border bg-ludo-background/60"
+          value={progress}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardPodium.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardPodium.tsx
@@ -9,15 +9,15 @@ type LeaderboardPodiumProps = {
 };
 
 const podiumHeights = {
-  1: "h-24",
-  2: "h-20",
-  3: "h-16",
+  1: "h-16 lg:h-24",
+  2: "h-14 lg:h-20",
+  3: "h-12 lg:h-16",
 };
 
 const podiumRankNumberSize = {
-  1: "text-4xl",
-  2: "text-3xl",
-  3: "text-[1.75rem]",
+  1: "text-2xl lg:text-4xl",
+  2: "text-xl lg:text-3xl",
+  3: "text-lg lg:text-[1.75rem]",
 };
 
 export function LeaderboardPodium({
@@ -25,7 +25,7 @@ export function LeaderboardPodium({
   topUsers,
 }: LeaderboardPodiumProps) {
   return (
-    <div className="flex w-full items-end gap-2">
+    <div className="flex w-full items-end gap-1.5 lg:gap-2">
       <PodiumPlayer currentUserId={currentUserId} user={topUsers[0]} rank={2} />
       <PodiumPlayer currentUserId={currentUserId} user={topUsers[1]} rank={1} />
       <PodiumPlayer currentUserId={currentUserId} user={topUsers[2]} rank={3} />
@@ -49,12 +49,14 @@ function PodiumPlayer({ currentUserId, user, rank }: PodiumPlayerProps) {
   const ownStyle = currentUserId == user?.userId ? "bg-ludo-accent" : ""
 
   return (
-    <div className="flex-1 min-w-0 flex flex-col gap-2">
-      <div className="flex min-w-0 items-center flex-col gap-2">
-        <Avatar className="h-13 w-13 lg:h-13 lg:w-13" src={avatarSrc} />
+    <div className="flex min-w-0 flex-1 flex-col gap-1 lg:gap-2">
+      <div className="flex min-w-0 flex-col items-center gap-1 lg:gap-2">
+        <Avatar className="size-10 lg:size-13" src={avatarSrc} />
         <div className="w-full flex flex-col min-w-0 items-center">
-          <p className="w-full truncate text-center">{displayName}</p>
-          <p className="font-bold text-xl">{points} XP</p>
+          <p className="w-full truncate text-center text-xs lg:text-base">
+            {displayName}
+          </p>
+          <p className="text-sm font-bold lg:text-xl">{points} XP</p>
         </div>
       </div>
       <div

--- a/packages/util/date/dateUtils.ts
+++ b/packages/util/date/dateUtils.ts
@@ -12,6 +12,14 @@ export const formatShortDate = (date: Date) => {
   return dayjs(date).format("MMM D, YYYY");
 };
 
+export const formatShortDateRange = (startDate: Date, endDate: Date) => {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).formatRange(startDate, endDate);
+};
+
 export const toDate = (
   timestamp: number,
   MILLISECOND_TIMESTAMP_THRESHOLD: number = 1_000_000_000_000,

--- a/packages/util/date/dateUtils.ts
+++ b/packages/util/date/dateUtils.ts
@@ -7,3 +7,27 @@ export const parseToDate = (dateTime: number) => {
 export const parseToDigitDate = (dateTime: number) => {
   return dayjs(dateTime * 1000).format("DD/MM/YYYY");
 };
+
+export const formatShortDate = (date: Date) => {
+  return dayjs(date).format("MMM D, YYYY");
+};
+
+export const toDate = (
+  timestamp: number,
+  MILLISECOND_TIMESTAMP_THRESHOLD: number = 1_000_000_000_000,
+): Date => {
+  return new Date(
+    timestamp < MILLISECOND_TIMESTAMP_THRESHOLD ? timestamp * 1000 : timestamp,
+  );
+};
+
+export const getDateRangeProgress = (
+  startDate: Date,
+  endDate: Date,
+  currentDate: Date = new Date(),
+): number => {
+  const duration = endDate.getTime() - startDate.getTime();
+  if (duration <= 0) return 0;
+  const elapsed = currentDate.getTime() - startDate.getTime();
+  return Math.min(100, Math.max(0, (elapsed / duration) * 100));
+};


### PR DESCRIPTION
## Summary
This PR adds a header showing the start and end dates of the current leaderboard session (mon-sun). It also shows a progress bar of how long is left until the week resets

## Changes
- Added `LeaderboardPeriodHeader`
- Made podium smaller on mobile devices in order to fit the header + podium
- Added some date utils for the leaderboard header in `dateUtils`

## Keywords
Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a leaderboard period header showing the active date range and progress.
  * Added short date and date-range formatting for clearer leaderboard timelines.

* **Enhancements**
  * Improved leaderboard podium responsiveness across screen sizes.
  * Updated player names, scores, and XP display for better readability.
  * Added reliable timestamp handling and date-range progress calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->