### PR TITLE
feat: Add resizable panes in workbench & guided projects

### DIFF
--- a/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
+++ b/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
@@ -26,6 +26,8 @@ import { buildProjectSystemPrompt } from "@ludocode/design-system/widgets/chatbo
 import { useGuidedExercise } from "@/features/lesson/guided/context/useGuidedExerciseContext.tsx";
 import { GuidedLessonActions } from "./components/GuidedLessonActions";
 import { MobileTabs, useMobileTabs } from "@ludocode/design-system/primitives/mobile-tabs"
+import { PaneResizeHandle } from "@/features/project/workbench/components/PaneResizeHandle";
+import { useResizableSidePanes } from "@/features/project/hooks/useResizableSidePanes";
 
 type GuidedMobilePane = "instructions" | "code" | "output";
 
@@ -62,6 +64,7 @@ export function GuidedExecutableWorkbench({
   const { runCode, stopCode, outputInfo } = useCodeRunnerContext();
   const runnerFeature = useFeatureEnabledCheck({ feature: "isPistonEnabled" });
   const isMobile = useIsMobile({});
+  const { isDesktop, left, right } = useResizableSidePanes();
   const { isRunning, outputLog } = outputInfo;
 
   const [awaitingValidation, setAwaitingValidation] = useState(false);
@@ -256,7 +259,15 @@ export function GuidedExecutableWorkbench({
           "transform-none transition-none animate-none",
           "lg:flex lg:flex-col lg:flex-1",
         )}
+        style={left.style}
       />
+
+      {isDesktop && (
+        <PaneResizeHandle
+          {...left.handleProps}
+          label="Resize instructions panel"
+        />
+      )}
 
       <GuidedExerciseEditorPane
         runOrAdvance={runOrAdvance}
@@ -307,6 +318,10 @@ export function GuidedExecutableWorkbench({
         />
       </GuidedExerciseEditorPane>
 
+      {isDesktop && (
+        <PaneResizeHandle {...right.handleProps} label="Resize output panel" />
+      )}
+
       <WorkbenchOutputPane
         successColorVariant="alt"
         className={cn(
@@ -314,6 +329,7 @@ export function GuidedExecutableWorkbench({
           "transform-none transition-none animate-none",
           "lg:flex lg:flex-1",
         )}
+        style={right.style}
       />
 
       <div className="lg:hidden border-t border-ludo-surface">

--- a/apps/web/src/features/lesson/guided/components/GuidedExerciseTreePane.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedExerciseTreePane.tsx
@@ -4,18 +4,21 @@ import type { LudoExercise } from "@ludocode/types";
 import { cn } from "@ludocode/design-system/cn-utils";
 import { useIsMobile } from "@ludocode/hooks";
 import { testIds } from "@ludocode/util/test-ids";
+import type { CSSProperties } from "react";
 
 type GuidedExerciseTreePaneProps = {
   showBlockOutput?: boolean;
   currentExercise: LudoExercise;
   systemPrompt: string;
   className?: string;
+  style?: CSSProperties;
 };
 
 export function GuidedExerciseTreePane({
   showBlockOutput = true,
   currentExercise,
   className,
+  style,
 }: GuidedExerciseTreePaneProps) {
   const isMobile = useIsMobile({});
   const instructionBlocks = currentExercise.blocks.filter(
@@ -25,6 +28,7 @@ export function GuidedExerciseTreePane({
   return (
     <Workbench.Pane
       dataTestId={testIds.guided.asideLeft}
+      style={style}
       className={cn("lg:border-r-2 border-r-ludo-surface", className)}
     >
       <Workbench.Pane.Winbar className="hidden lg:block">

--- a/apps/web/src/features/project/hooks/useResizableSidePanes.tsx
+++ b/apps/web/src/features/project/hooks/useResizableSidePanes.tsx
@@ -1,0 +1,52 @@
+import { useState, type CSSProperties } from "react";
+import { useIsMobile } from "@ludocode/hooks";
+
+const DESKTOP_BREAKPOINT = 1024;
+const LEFT_PANE = { min: 240, maxFraction: 0.34 };
+const RIGHT_PANE = { min: 320, maxFraction: 0.42 };
+
+export type SidePane = {
+  style: CSSProperties | undefined;
+  handleProps: {
+    pane: "left" | "right";
+    width: number | null;
+    onResize: (width: number) => void;
+    min: number;
+    maxFraction: number;
+  };
+};
+
+export function useResizableSidePanes(): {
+  isDesktop: boolean;
+  left: SidePane;
+  right: SidePane;
+} {
+  const isDesktop = !useIsMobile({ mobileBreakpoint: DESKTOP_BREAKPOINT });
+  const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const [rightWidth, setRightWidth] = useState<number | null>(null);
+
+  const paneStyle = (width: number | null) =>
+    width !== null && isDesktop ? { width, flex: "0 0 auto" } : undefined;
+
+  return {
+    isDesktop,
+    left: {
+      style: paneStyle(leftWidth),
+      handleProps: {
+        pane: "left",
+        width: leftWidth,
+        onResize: setLeftWidth,
+        ...LEFT_PANE,
+      },
+    },
+    right: {
+      style: paneStyle(rightWidth),
+      handleProps: {
+        pane: "right",
+        width: rightWidth,
+        onResize: setRightWidth,
+        ...RIGHT_PANE,
+      },
+    },
+  };
+}

--- a/apps/web/src/features/project/workbench/WorkbenchPage.tsx
+++ b/apps/web/src/features/project/workbench/WorkbenchPage.tsx
@@ -16,14 +16,10 @@ import { useMobileTabs } from "@ludocode/design-system/primitives/mobile-tabs";
 import { FooterCTAGroup } from "@/features/auth/components/FooterCTAGroup";
 import { WorkbenchMobileTabs, type WorkbenchMobilePane } from "./components/WorkbenchMobileTabs.tsx";
 import { PaneResizeHandle } from "./components/PaneResizeHandle.tsx";
-import { useState } from "react";
-
-const DESKTOP_BREAKPOINT = 1024;
-const LEFT_PANE = { min: 240, maxFraction: 0.34 };
-const RIGHT_PANE = { min: 320, maxFraction: 0.42 };
-
-const paneWidthStyle = (width: number | null, isDesktop: boolean) =>
-  width !== null && isDesktop ? { width, flex: "0 0 auto" } : undefined;
+import {
+  useResizableSidePanes,
+  type SidePane,
+} from "@/features/project/hooks/useResizableSidePanes.tsx";
 
 type WorkbenchPageProps = {
   readOnly?: boolean;
@@ -39,9 +35,7 @@ export function WorkbenchPage({
   const isWebProject = project.projectType === "WEB";
   const runnerFeature = useFeatureEnabledCheck({ feature: "isPistonEnabled" });
   const isMobile = useIsMobile({});
-  const isDesktop = !useIsMobile({ mobileBreakpoint: DESKTOP_BREAKPOINT });
-  const [leftWidth, setLeftWidth] = useState<number | null>(null);
-  const [rightWidth, setRightWidth] = useState<number | null>(null);
+  const { isDesktop, left, right } = useResizableSidePanes();
   const { activeTab: mobilePane, selectTab: setMobilePane } =
     useMobileTabs<WorkbenchMobilePane>("code");
 
@@ -51,21 +45,14 @@ export function WorkbenchPage({
         showAi={!isMobile}
         readOnly={readOnly}
         className={cn(mobilePane === "files" ? "flex-1" : "hidden", "lg:grid")}
-        style={paneWidthStyle(leftWidth, isDesktop)}
+        style={left.style}
         onFileSelect={() => {
           if (!isMobile) return;
           setMobilePane("code");
         }}
       />
       {isDesktop && (
-        <PaneResizeHandle
-          pane="left"
-          label="Resize files panel"
-          width={leftWidth}
-          onResize={setLeftWidth}
-          min={LEFT_PANE.min}
-          maxFraction={LEFT_PANE.maxFraction}
-        />
+        <PaneResizeHandle {...left.handleProps} label="Resize files panel" />
       )}
       <CodeRunnerProvider
         project={project}
@@ -86,8 +73,7 @@ export function WorkbenchPage({
           setMobilePane={setMobilePane}
           runnerEnabled={runnerFeature.enabled === true}
           isDesktop={isDesktop}
-          rightWidth={rightWidth}
-          setRightWidth={setRightWidth}
+          rightPane={right}
         />
       </CodeRunnerProvider>
     </div>
@@ -107,8 +93,7 @@ function WorkbenchPageContent({
   setMobilePane,
   runnerEnabled,
   isDesktop,
-  rightWidth,
-  setRightWidth,
+  rightPane,
 }: {
   projectId: string;
   entryFilePath: string;
@@ -122,8 +107,7 @@ function WorkbenchPageContent({
   setMobilePane: (pane: WorkbenchMobilePane) => void;
   runnerEnabled: boolean;
   isDesktop: boolean;
-  rightWidth: number | null;
-  setRightWidth: (width: number) => void;
+  rightPane: SidePane;
 }) {
   return (
     <>
@@ -155,12 +139,8 @@ function WorkbenchPageContent({
 
       {isDesktop && (
         <PaneResizeHandle
-          pane="right"
+          {...rightPane.handleProps}
           label={isWebProject ? "Resize preview panel" : "Resize output panel"}
-          width={rightWidth}
-          onResize={setRightWidth}
-          min={RIGHT_PANE.min}
-          maxFraction={RIGHT_PANE.maxFraction}
         />
       )}
 
@@ -173,7 +153,7 @@ function WorkbenchPageContent({
             mobilePane === "output" ? "flex-1" : "hidden",
             "lg:flex lg:flex-1",
           )}
-          style={paneWidthStyle(rightWidth, isDesktop)}
+          style={rightPane.style}
         />
       ) : (
         <WorkbenchOutputPane
@@ -181,7 +161,7 @@ function WorkbenchPageContent({
             mobilePane === "output" ? "flex-1" : "hidden",
             "lg:flex lg:flex-1",
           )}
-          style={paneWidthStyle(rightWidth, isDesktop)}
+          style={rightPane.style}
         />
       )}
 

--- a/apps/web/src/features/project/workbench/WorkbenchPage.tsx
+++ b/apps/web/src/features/project/workbench/WorkbenchPage.tsx
@@ -15,6 +15,15 @@ import { useIsMobile } from "@ludocode/hooks";
 import { useMobileTabs } from "@ludocode/design-system/primitives/mobile-tabs";
 import { FooterCTAGroup } from "@/features/auth/components/FooterCTAGroup";
 import { WorkbenchMobileTabs, type WorkbenchMobilePane } from "./components/WorkbenchMobileTabs.tsx";
+import { PaneResizeHandle } from "./components/PaneResizeHandle.tsx";
+import { useState } from "react";
+
+const DESKTOP_BREAKPOINT = 1024;
+const LEFT_PANE = { min: 240, maxFraction: 0.34 };
+const RIGHT_PANE = { min: 320, maxFraction: 0.42 };
+
+const paneWidthStyle = (width: number | null, isDesktop: boolean) =>
+  width !== null && isDesktop ? { width, flex: "0 0 auto" } : undefined;
 
 type WorkbenchPageProps = {
   readOnly?: boolean;
@@ -30,6 +39,9 @@ export function WorkbenchPage({
   const isWebProject = project.projectType === "WEB";
   const runnerFeature = useFeatureEnabledCheck({ feature: "isPistonEnabled" });
   const isMobile = useIsMobile({});
+  const isDesktop = !useIsMobile({ mobileBreakpoint: DESKTOP_BREAKPOINT });
+  const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const [rightWidth, setRightWidth] = useState<number | null>(null);
   const { activeTab: mobilePane, selectTab: setMobilePane } =
     useMobileTabs<WorkbenchMobilePane>("code");
 
@@ -39,11 +51,22 @@ export function WorkbenchPage({
         showAi={!isMobile}
         readOnly={readOnly}
         className={cn(mobilePane === "files" ? "flex-1" : "hidden", "lg:grid")}
+        style={paneWidthStyle(leftWidth, isDesktop)}
         onFileSelect={() => {
           if (!isMobile) return;
           setMobilePane("code");
         }}
       />
+      {isDesktop && (
+        <PaneResizeHandle
+          pane="left"
+          label="Resize files panel"
+          width={leftWidth}
+          onResize={setLeftWidth}
+          min={LEFT_PANE.min}
+          maxFraction={LEFT_PANE.maxFraction}
+        />
+      )}
       <CodeRunnerProvider
         project={project}
         files={files}
@@ -62,6 +85,9 @@ export function WorkbenchPage({
           mobilePane={mobilePane}
           setMobilePane={setMobilePane}
           runnerEnabled={runnerFeature.enabled === true}
+          isDesktop={isDesktop}
+          rightWidth={rightWidth}
+          setRightWidth={setRightWidth}
         />
       </CodeRunnerProvider>
     </div>
@@ -80,6 +106,9 @@ function WorkbenchPageContent({
   mobilePane,
   setMobilePane,
   runnerEnabled,
+  isDesktop,
+  rightWidth,
+  setRightWidth,
 }: {
   projectId: string;
   entryFilePath: string;
@@ -92,6 +121,9 @@ function WorkbenchPageContent({
   mobilePane: WorkbenchMobilePane;
   setMobilePane: (pane: WorkbenchMobilePane) => void;
   runnerEnabled: boolean;
+  isDesktop: boolean;
+  rightWidth: number | null;
+  setRightWidth: (width: number) => void;
 }) {
   return (
     <>
@@ -121,6 +153,17 @@ function WorkbenchPageContent({
         )}
       </Workbench.Pane>
 
+      {isDesktop && (
+        <PaneResizeHandle
+          pane="right"
+          label={isWebProject ? "Resize preview panel" : "Resize output panel"}
+          width={rightWidth}
+          onResize={setRightWidth}
+          min={RIGHT_PANE.min}
+          maxFraction={RIGHT_PANE.maxFraction}
+        />
+      )}
+
       {isWebProject ? (
         <WorkbenchLivePreviewPane
           filePath={entryFilePath}
@@ -130,6 +173,7 @@ function WorkbenchPageContent({
             mobilePane === "output" ? "flex-1" : "hidden",
             "lg:flex lg:flex-1",
           )}
+          style={paneWidthStyle(rightWidth, isDesktop)}
         />
       ) : (
         <WorkbenchOutputPane
@@ -137,6 +181,7 @@ function WorkbenchPageContent({
             mobilePane === "output" ? "flex-1" : "hidden",
             "lg:flex lg:flex-1",
           )}
+          style={paneWidthStyle(rightWidth, isDesktop)}
         />
       )}
 

--- a/apps/web/src/features/project/workbench/components/PaneResizeHandle.tsx
+++ b/apps/web/src/features/project/workbench/components/PaneResizeHandle.tsx
@@ -1,0 +1,118 @@
+import { useLayoutEffect, useRef, useState, type PointerEvent } from "react";
+import { cn } from "@ludocode/design-system/cn-utils.ts";
+
+type PaneResizeHandleProps = {
+  width: number | null;
+  onResize: (width: number) => void;
+  min: number;
+  maxFraction: number;
+  pane: "left" | "right";
+  label: string;
+  className?: string;
+};
+
+const KEYBOARD_STEP = 16;
+
+export function PaneResizeHandle({
+  width,
+  onResize,
+  min,
+  maxFraction,
+  pane,
+  label,
+  className,
+}: PaneResizeHandleProps) {
+  const handleRef = useRef<HTMLDivElement>(null);
+  const initialWidth = useRef<number | null>(null);
+  const dragStart = useRef<{ x: number; width: number } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const paneElement = () => {
+    const el = handleRef.current;
+    return (
+      pane === "left" ? el?.previousElementSibling : el?.nextElementSibling
+    ) as HTMLElement | undefined | null;
+  };
+
+  const measurePane = () => paneElement()?.getBoundingClientRect().width ?? 0;
+
+  const clamp = (value: number) => {
+    const row = handleRef.current?.parentElement?.clientWidth ?? 0;
+    const start = initialWidth.current ?? value;
+    const low = Math.min(min, start);
+    const high = row > 0 ? Math.max(low, start, row * maxFraction) : Infinity;
+    return Math.min(high, Math.max(low, value));
+  };
+
+  useLayoutEffect(() => {
+    if (width !== null) return;
+    const measured = measurePane();
+    if (measured <= 0) return;
+    initialWidth.current = measured;
+    onResize(measured);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width]);
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragStart.current = { x: event.clientX, width: width ?? measurePane() };
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const start = dragStart.current;
+    if (!start) return;
+    const delta =
+      pane === "left" ? event.clientX - start.x : start.x - event.clientX;
+    onResize(clamp(start.width + delta));
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    if (!dragStart.current) return;
+    dragStart.current = null;
+    setIsDragging(false);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  };
+
+  return (
+    <div
+      ref={handleRef}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      aria-valuenow={width ?? undefined}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onKeyDown={(event) => {
+        const towards = pane === "left" ? 1 : -1;
+        const current = width ?? measurePane();
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          onResize(clamp(current - KEYBOARD_STEP * towards));
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          onResize(clamp(current + KEYBOARD_STEP * towards));
+        }
+      }}
+      className={cn(
+        "group hidden lg:block relative z-10 w-0 shrink-0 self-stretch outline-none",
+        className,
+      )}
+    >
+      <span className="absolute inset-y-0 -left-1 w-2 cursor-col-resize touch-none select-none">
+        <span
+          className={cn(
+            "absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 transition-colors",
+            isDragging
+              ? "bg-ludo-accent-muted/40"
+              : "bg-transparent group-hover:bg-ludo-accent-muted/20",
+          )}
+        />
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/features/project/workbench/components/PaneResizeHandle.tsx
+++ b/apps/web/src/features/project/workbench/components/PaneResizeHandle.tsx
@@ -1,4 +1,10 @@
-import { useLayoutEffect, useRef, useState, type PointerEvent } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type PointerEvent,
+} from "react";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
 
 type PaneResizeHandleProps = {
@@ -38,9 +44,9 @@ export function PaneResizeHandle({
 
   const clamp = (value: number) => {
     const row = handleRef.current?.parentElement?.clientWidth ?? 0;
-    const start = initialWidth.current ?? value;
-    const low = Math.min(min, start);
-    const high = row > 0 ? Math.max(low, start, row * maxFraction) : Infinity;
+    if (row <= 0) return value;
+    const high = row * maxFraction;
+    const low = Math.min(min, initialWidth.current ?? value, high);
     return Math.min(high, Math.max(low, value));
   };
 
@@ -52,6 +58,25 @@ export function PaneResizeHandle({
     onResize(measured);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [width]);
+
+  const widthRef = useRef(width);
+  widthRef.current = width;
+
+  useEffect(() => {
+    const row = handleRef.current?.parentElement;
+    if (!row) return;
+
+    const observer = new ResizeObserver(() => {
+      const current = widthRef.current;
+      if (current === null || dragStart.current) return;
+      const next = clamp(current);
+      if (Math.abs(next - current) > 0.5) onResize(next);
+    });
+
+    observer.observe(row);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [min, maxFraction]);
 
   const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
     event.preventDefault();

--- a/apps/web/src/features/project/workbench/zones/WorkbenchLivePreviewPane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchLivePreviewPane.tsx
@@ -2,13 +2,14 @@ import { WEB_CDN_BASE_URL } from "@/constants/environment/env.ts";
 import { IconButton } from "@ludocode/design-system/primitives/icon-button.tsx";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
 import { Workbench } from "@ludocode/design-system/widgets/workbench";
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { testIds } from "@ludocode/util";
 
 type WorkbenchLivePreviewPaneProps = {
     projectId: string;
     filePath: string;
     className?: string;
+    style?: CSSProperties;
     refreshVersion?: number;
     hideWinbarOnMobile?: boolean;
 };
@@ -24,6 +25,7 @@ export function WorkbenchLivePreviewPane({
     filePath,
     refreshVersion = 0,
     className,
+    style,
     hideWinbarOnMobile = false,
 }: WorkbenchLivePreviewPaneProps) {
     const [manualRefreshVersion, setManualRefreshVersion] = useState(0);
@@ -35,6 +37,7 @@ export function WorkbenchLivePreviewPane({
 
     return (
         <Workbench.Pane
+            style={style}
             className={cn(
                 "grid-rows-[auto_1fr]",
                 "col-span-1 lg:border-l-2 border-l-ludo-surface lg:col-span-3 flex flex-col min-h-0",

--- a/apps/web/src/features/project/workbench/zones/WorkbenchOutputPane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchOutputPane.tsx
@@ -6,18 +6,20 @@ import {
 } from "@ludocode/design-system/widgets/ludo-log.tsx";
 import { useCodeRunnerContext } from "@/features/project/workbench/context/CodeRunnerContext.tsx";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { testIds } from "@ludocode/util/test-ids";
 
 type WorkbenchOutputPaneProps = {
   successColorVariant?: OutputTriggerColorVariant;
   className?: string;
+  style?: CSSProperties;
   hideWinbarOnMobile?: boolean;
 };
 
 export function WorkbenchOutputPane({
   successColorVariant = "default",
   className,
+  style,
   hideWinbarOnMobile = false,
 }: WorkbenchOutputPaneProps) {
   const { outputInfo, sendStdin } = useCodeRunnerContext();
@@ -34,6 +36,7 @@ export function WorkbenchOutputPane({
 
   return (
     <Workbench.Pane
+      style={style}
       className={cn(
         "grid-rows-[auto_1fr_auto]",
         "col-span-1 lg:border-l-2 border-l-ludo-surface lg:col-span-3 flex flex-col",

--- a/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
@@ -92,7 +92,7 @@ export function WorkbenchTreePane({
             }
           />
         </Workbench.Pane.Winbar>
-        <Workbench.Pane.Content>
+        <Workbench.Pane.Content className="lg:pr-4">
           <LudoFileTree
             selectedId={currentFileId}
             onSelect={(id) => {

--- a/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
@@ -24,13 +24,14 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@ludocode/external/ui/tooltip.tsx";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, type CSSProperties } from "react";
 import { Languages } from "@ludocode/types/Project/ProjectFileSnapshot.ts";
 import { testIds } from "@ludocode/util/test-ids";
 
 type WorkbenchTreePaneProps = {
   readOnly?: boolean;
   className?: string;
+  style?: CSSProperties;
   showAi?: boolean;
   onFileSelect?: () => void;
 };
@@ -38,6 +39,7 @@ type WorkbenchTreePaneProps = {
 export function WorkbenchTreePane({
   readOnly,
   className,
+  style,
   showAi,
   onFileSelect,
 }: WorkbenchTreePaneProps) {
@@ -72,6 +74,7 @@ export function WorkbenchTreePane({
     <>
       <Workbench.Pane
         dataTestId={testIds.project.asideLeft}
+        style={style}
         className={cn(
           "border-r-2 flex-1 border-r-ludo-surface grid-rows-[auto_minmax(0,1fr)_auto]",
           className,

--- a/packages/design-system/widgets/workbench.tsx
+++ b/packages/design-system/widgets/workbench.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@ludocode/design-system/cn-utils";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 type WorkbenchProps = {
   children?: ReactNode;
@@ -16,12 +16,19 @@ type WorkbenchPaneProps = {
   children: ReactNode;
   className?: string;
   dataTestId?: string;
+  style?: CSSProperties;
 };
 
-export function Pane({ children, className, dataTestId }: WorkbenchPaneProps) {
+export function Pane({
+  children,
+  className,
+  dataTestId,
+  style,
+}: WorkbenchPaneProps) {
   return (
     <div
       data-testid={dataTestId}
+      style={style}
       className={cn(
         "flex-1 min-w-0 w-full min-h-0 bg-ludo-background grid grid-rows-[auto_1fr] lg:col-span-3",
         className,

--- a/packages/hooks/guard/useIsMobile.tsx
+++ b/packages/hooks/guard/useIsMobile.tsx
@@ -7,7 +7,11 @@ export function useIsMobile({
 }: {
   mobileBreakpoint?: number;
 }) {
-  const [isMobile, setIsMobile] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`).matches,
+  );
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`);


### PR DESCRIPTION
## Summary
This PR adds resizable panes on the workbench pages and guided project pages. It also fixes a small UI issue where the tree pane items did not have padding on the right side and stuck to the border.

## Changes
- Added `useResizableSidePanes` hook
- Refactored `WorkbenchPage` and `GuidedExecutableWorkbench` to use the new resizable panes
- Added padding to the `Workbench.Pane.Content` holding the `LudoFileTree`

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resizable left and right panes to desktop workbenches.
  * Resize panes by dragging or using keyboard controls, with accessible labels and size limits.
  * Guided exercises now support adjustable instruction, editor, and output areas.
* **Bug Fixes**
  * Improved responsive layout detection for mobile and server-rendered views.
  * Added spacing adjustments for clearer pane content on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->