### PR TITLE
feat: Add descriptions to projects

### DIFF
--- a/apps/web/src/features/project/hub/components/ProjectCard.tsx
+++ b/apps/web/src/features/project/hub/components/ProjectCard.tsx
@@ -78,8 +78,8 @@ function OwnProjectCard({
   const {
     projectId,
     projectTitle,
+    description,
     updatedAt,
-    createdAt,
     visibility,
     technologies,
     authorId,
@@ -113,6 +113,7 @@ function OwnProjectCard({
           <ProjectActionsMenu
             projectId={projectId}
             projectTitle={projectTitle}
+            projectDescription={description}
           />
         </div>
       </div>
@@ -123,8 +124,21 @@ function OwnProjectCard({
         onClick={() => openProject(authorId, projectId)}
         className="flex flex-1 flex-col gap-2 p-4 text-left hover:cursor-pointer"
       >
-        <MetaRow label="Updated" value={parseToDate(updatedAt)} />
-        <MetaRow label="Created" value={parseToDate(createdAt)} />
+        {description ? (
+          <p className="line-clamp-2 text-xs leading-relaxed text-ludo-white">
+            {description}
+          </p>
+        ) : (
+          <p className="text-xs italic leading-relaxed text-ludo-white-disabled">
+            No description yet
+          </p>
+        )}
+
+        <MetaRow
+          className="mt-auto"
+          label="Updated"
+          value={parseToDate(updatedAt)}
+        />
 
         {deleteAt && (
           <p className="text-xs leading-tight text-ludo-danger">
@@ -132,7 +146,7 @@ function OwnProjectCard({
           </p>
         )}
 
-        <div className="mt-auto flex items-center justify-between gap-2 pt-3">
+        <div className="flex items-center justify-between gap-2">
           <TechnologyIcons project={project} />
           <span className="flex items-center gap-1.5 text-xs font-semibold text-ludo-accent-muted">
             Open
@@ -144,9 +158,17 @@ function OwnProjectCard({
   );
 }
 
-function MetaRow({ label, value }: { label: string; value: string }) {
+function MetaRow({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}) {
   return (
-    <div className="flex items-baseline justify-between gap-2">
+    <div className={cn("flex items-baseline justify-between gap-2", className)}>
       <span className="text-[10px] uppercase tracking-widest text-ludo-white-dim">
         {label}
       </span>
@@ -162,7 +184,7 @@ function CommunityProjectCard({
   project: ProjectCardResponse;
   currentUserId?: string;
 }) {
-  const { projectId, projectTitle, createdAt, authorId } = project;
+  const { projectId, projectTitle, description, createdAt, authorId } = project;
 
   const { data: author } = useQuery(qo.user(authorId));
   const authorDisplayName = author?.displayName?.trim() || "Anonymous";
@@ -194,9 +216,14 @@ function CommunityProjectCard({
           </div>
         </div>
 
-        <p className="mt-auto truncate text-lg font-bold leading-tight text-ludo-white-bright">
-          {projectTitle}
-        </p>
+        <div className="flex flex-col gap-1">
+          <p className="truncate text-lg font-bold leading-tight text-ludo-white-bright">
+            {projectTitle}
+          </p>
+          <p className="line-clamp-2 text-xs leading-relaxed text-ludo-white">
+            {description || "No description"}
+          </p>
+        </div>
       </button>
 
       <div
@@ -223,12 +250,17 @@ function CommunityProjectCard({
 function ProjectActionsMenu({
   projectId,
   projectTitle,
+  projectDescription,
 }: {
   projectId: string;
   projectTitle: string;
+  projectDescription: string;
 }) {
-  const { handleRenameProject, handleDeleteProject } =
-    useModifyProject(projectId);
+  const {
+    handleRenameProject,
+    handleChangeProjectDescription,
+    handleDeleteProject,
+  } = useModifyProject(projectId);
   return (
     <FileActionsMenu
       trigger={
@@ -247,7 +279,9 @@ function ProjectActionsMenu({
       itemType={"project"}
       targetId={projectId}
       targetName={projectTitle}
+      targetDescription={projectDescription}
       renameItem={handleRenameProject}
+      describeItem={handleChangeProjectDescription}
       deleteItem={handleDeleteProject}
     />
   );

--- a/apps/web/src/features/project/workbench/components/FileActionsMenu.tsx
+++ b/apps/web/src/features/project/workbench/components/FileActionsMenu.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { LudoMenu } from "@ludocode/design-system/widgets/ludo-menu.tsx";
 import { HeroIcon } from "@ludocode/design-system/primitives/hero-icon.tsx";
 import { RenameDialog } from "@ludocode/design-system/templates/dialog/rename-dialog.tsx";
+import { DescriptionDialog } from "@ludocode/design-system/templates/dialog/description-dialog.tsx";
 import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog.tsx";
 
 type FileActionsMenuProps = {
@@ -13,6 +14,8 @@ type FileActionsMenuProps = {
   deleteItem: () => void;
   canDelete?: boolean;
   canRename?: boolean;
+  targetDescription?: string;
+  describeItem?: (oldDescription: string, newDescription: string) => void;
 };
 
 export function FileActionsMenu({
@@ -24,12 +27,14 @@ export function FileActionsMenu({
   deleteItem,
   canDelete = true,
   canRename = true,
+  targetDescription,
+  describeItem,
 }: FileActionsMenuProps) {
   return (
     <LudoMenu>
       <LudoMenu.Trigger>{trigger}</LudoMenu.Trigger>
 
-      <LudoMenu.Content  align="end">
+      <LudoMenu.Content align="end">
         {canRename && (
           <RenameDialog
             itemCategory={itemType}
@@ -49,6 +54,27 @@ export function FileActionsMenu({
               </LudoMenu.Row>
             </LudoMenu.Item>
           </RenameDialog>
+        )}
+
+        {describeItem && (
+          <DescriptionDialog
+            itemCategory={itemType}
+            key={`describe-${targetId}`}
+            itemDescription={targetDescription ?? ""}
+            onSubmit={describeItem}
+          >
+            <LudoMenu.Item closeOnSelect={false}>
+              <LudoMenu.Row>
+                <LudoMenu.Icon>
+                  <HeroIcon
+                    iconName="DocumentTextIcon"
+                    className="h-4 text-ludo-white-bright/70"
+                  />
+                </LudoMenu.Icon>
+                <LudoMenu.Label>Describe</LudoMenu.Label>
+              </LudoMenu.Row>
+            </LudoMenu.Item>
+          </DescriptionDialog>
         )}
 
         {canDelete && (

--- a/apps/web/src/queries/definitions/mutations.ts
+++ b/apps/web/src/queries/definitions/mutations.ts
@@ -8,6 +8,7 @@ import type { OnboardingSubmission } from "@ludocode/types/Onboarding/Onboarding
 import { type ProjectSnapshot } from "@ludocode/types/Project/ProjectSnapshot.ts";
 import { type CreateProjectRequest } from "@ludocode/types/Project/CreateProjectRequest.ts";
 import type { RenameProjectRequest } from "@ludocode/types/Project/RenameProjectRequest.ts";
+import type { ChangeProjectDescriptionRequest } from "@ludocode/types/Project/ChangeProjectDescriptionRequest.ts";
 import {
   ludoPut,
   ludoPatch,
@@ -142,6 +143,18 @@ export const mutations = {
     });
   },
 
+  changeProjectDescription: () => {
+    return mutationOptions<void, Error, ChangeProjectDescriptionRequest>({
+      mutationKey: ["changeProjectDescription"],
+      mutationFn: (variables) =>
+        ludoPatch<void, ChangeProjectDescriptionRequest>(
+          api.projects.description(variables.targetId),
+          variables,
+          true,
+        ),
+    });
+  },
+
   changeProjectVisibility: (pid: string) => {
     return mutationOptions<void, Error, ChangeProjectVisibilityRequest>({
       mutationKey: ["changeProjectVisibility"],
@@ -186,7 +199,11 @@ export const mutations = {
     return mutationOptions<MessageLikeCountResponse, Error, void>({
       mutationKey: ["likeMessage"],
       mutationFn: () =>
-        ludoPost<MessageLikeCountResponse>(api.discussion.likeById(mid), null, true),
+        ludoPost<MessageLikeCountResponse>(
+          api.discussion.likeById(mid),
+          null,
+          true,
+        ),
     });
   },
 
@@ -194,7 +211,10 @@ export const mutations = {
     return mutationOptions<MessageLikeCountResponse, Error, void>({
       mutationKey: ["unlikeMessage"],
       mutationFn: () =>
-        ludoDelete<MessageLikeCountResponse>(api.discussion.likeById(mid), true),
+        ludoDelete<MessageLikeCountResponse>(
+          api.discussion.likeById(mid),
+          true,
+        ),
     });
   },
 
@@ -226,12 +246,8 @@ export const mutations = {
     return mutationOptions<LudoUser, Error, AvatarInfo>({
       mutationKey: ["changeAvatar"],
       mutationFn: (variables) =>
-        ludoPut<LudoUser, AvatarInfo>(
-          api.users.avatar,
-          variables,
-          true
-        )
-    })
+        ludoPut<LudoUser, AvatarInfo>(api.users.avatar, variables, true),
+    });
   },
 
   editProfile: () => {

--- a/apps/web/src/queries/mutations/projectMutations.ts
+++ b/apps/web/src/queries/mutations/projectMutations.ts
@@ -28,6 +28,18 @@ export function useRenameProject(pid: string) {
   });
 }
 
+export function useChangeProjectDescription(pid: string) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    ...mutations.changeProjectDescription(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: qk.projects() });
+      qc.invalidateQueries({ queryKey: qk.project(pid) });
+    },
+  });
+}
+
 export function useChangeProjectVisibility(pid: string) {
   const qc = useQueryClient();
 
@@ -55,6 +67,7 @@ export function useDeleteProject(pid: string) {
 export function useModifyProject(projectId: string) {
   const renameProjectMutation = useRenameProject(projectId);
   const deleteProjectMutation = useDeleteProject(projectId);
+  const changeDescriptionMutation = useChangeProjectDescription(projectId);
 
   const handleRenameProject = useCallback(
     (oldName: string, newName: string) => {
@@ -64,12 +77,24 @@ export function useModifyProject(projectId: string) {
     [projectId, renameProjectMutation],
   );
 
+  const handleChangeProjectDescription = useCallback(
+    (oldDescription: string, newDescription: string) => {
+      if (oldDescription === newDescription) return;
+      changeDescriptionMutation.mutate({
+        targetId: projectId,
+        newDescription: newDescription,
+      });
+    },
+    [projectId, changeDescriptionMutation],
+  );
+
   const handleDeleteProject = useCallback(() => {
     deleteProjectMutation.mutate();
   }, [deleteProjectMutation]);
 
   return {
     handleRenameProject,
+    handleChangeProjectDescription,
     handleDeleteProject,
   };
 }

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -127,6 +127,7 @@ export function createApiPaths({
       byIdPublic: (projectId: string) => `${BASE}/projects/public/${projectId}`,
       like: (projectId: string) => `${BASE}/projects/${projectId}/like`,
       name: (projectId: string) => `${BASE}/projects/${projectId}/name`,
+      description: (projectId: string) => `${BASE}/projects/${projectId}/description`,
       visibility: (projectId: string) =>
         `${BASE}/projects/${projectId}/visibility`,
       duplicate: (projectId: string) =>

--- a/packages/design-system/templates/dialog/description-dialog.tsx
+++ b/packages/design-system/templates/dialog/description-dialog.tsx
@@ -1,0 +1,53 @@
+import { useState, type ReactNode } from "react";
+import { DialogTitle } from "@ludocode/external/ui/dialog";
+import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
+import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
+import { Textarea } from "@ludocode/external/ui/textarea";
+
+type DescriptionDialogProps = {
+  itemDescription: string;
+  onSubmit: (oldDescription: string, newDescription: string) => void;
+  children: ReactNode;
+  itemCategory: string;
+};
+
+export function DescriptionDialog({
+  itemDescription,
+  children,
+  itemCategory,
+  onSubmit,
+}: DescriptionDialogProps) {
+  const oldDescription = itemDescription;
+  const [textBuffer, setTextBuffer] = useState<string>(itemDescription);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <LudoDialog
+      asChild={false}
+      open={open}
+      onOpenChange={setOpen}
+      trigger={children}
+    >
+      <DialogTitle className="text-ludo-white-bright">
+        Describe {itemCategory}
+      </DialogTitle>
+      <Textarea
+        className="min-h-24 resize-none text-ludo-white"
+        value={textBuffer}
+        maxLength={280}
+        placeholder={`What is this ${itemCategory} about?`}
+        onChange={(e) => setTextBuffer(e.target.value)}
+      />
+      <LudoButton
+        variant="alt"
+        className="w-full h-10"
+        onClick={() => {
+          onSubmit(oldDescription, textBuffer.trim());
+          setOpen(false);
+        }}
+      >
+        <p>Save</p>
+      </LudoButton>
+    </LudoDialog>
+  );
+}

--- a/packages/design-system/templates/dialog/description-dialog.tsx
+++ b/packages/design-system/templates/dialog/description-dialog.tsx
@@ -24,11 +24,16 @@ export function DescriptionDialog({
   const trimmed = textBuffer.trim();
   const isBlank = trimmed.length === 0;
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) setTextBuffer(itemDescription);
+    setOpen(nextOpen);
+  };
+
   return (
     <LudoDialog
       asChild={false}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleOpenChange}
       trigger={children}
     >
       <DialogTitle className="text-ludo-white-bright">

--- a/packages/design-system/templates/dialog/description-dialog.tsx
+++ b/packages/design-system/templates/dialog/description-dialog.tsx
@@ -21,6 +21,9 @@ export function DescriptionDialog({
   const [textBuffer, setTextBuffer] = useState<string>(itemDescription);
   const [open, setOpen] = useState(false);
 
+  const trimmed = textBuffer.trim();
+  const isBlank = trimmed.length === 0;
+
   return (
     <LudoDialog
       asChild={false}
@@ -41,8 +44,11 @@ export function DescriptionDialog({
       <LudoButton
         variant="alt"
         className="w-full h-10"
+        disabled={isBlank}
+        clickable={!isBlank}
         onClick={() => {
-          onSubmit(oldDescription, textBuffer.trim());
+          if (isBlank) return;
+          onSubmit(oldDescription, trimmed);
           setOpen(false);
         }}
       >

--- a/packages/design-system/templates/dialog/rename-dialog.tsx
+++ b/packages/design-system/templates/dialog/rename-dialog.tsx
@@ -24,11 +24,16 @@ export function RenameDialog({
   const trimmed = textBuffer.trim();
   const isBlank = trimmed.length === 0;
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) setTextBuffer(itemName);
+    setOpen(nextOpen);
+  };
+
   return (
     <LudoDialog
       asChild={false}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleOpenChange}
       trigger={children}
     >
       <DialogTitle className="text-ludo-white-bright">

--- a/packages/design-system/templates/dialog/rename-dialog.tsx
+++ b/packages/design-system/templates/dialog/rename-dialog.tsx
@@ -21,6 +21,9 @@ export function RenameDialog({
   const [textBuffer, setTextBuffer] = useState<string>(itemName);
   const [open, setOpen] = useState(false);
 
+  const trimmed = textBuffer.trim();
+  const isBlank = trimmed.length === 0;
+
   return (
     <LudoDialog
       asChild={false}
@@ -39,7 +42,10 @@ export function RenameDialog({
       <LudoButton
         variant="alt"
         className="w-full h-10"
+        disabled={isBlank}
+        clickable={!isBlank}
         onClick={() => {
+          if (isBlank) return;
           onSubmit(oldPath, textBuffer);
           setOpen(false);
         }}

--- a/packages/types/Project/ChangeProjectDescriptionRequest.ts
+++ b/packages/types/Project/ChangeProjectDescriptionRequest.ts
@@ -1,0 +1,4 @@
+export type ChangeProjectDescriptionRequest = {
+  targetId: string;
+  newDescription: string;
+};

--- a/packages/types/Project/ProjectCardResponse.ts
+++ b/packages/types/Project/ProjectCardResponse.ts
@@ -10,6 +10,7 @@ export type ProjectCardResponse = {
   deleteAt?: string;
   visibility: ProjectVisibility;
   technologies: LanguageKey[];
+  description: string;
 };
 
 export type ProjectCardResponseList = {


### PR DESCRIPTION
## Summary
This PR adds a `description` property to the `ProjectCardResponse` type. It adds a mutation allowing the user to change their project descriptions, and displays the description as part of the project card in the hub pages.

## Changes
- Added `description` path to project api paths in `api-paths.ts`
- Added description mutation to `projectMutations.ts`
- Added descriptions to `ProjectCard.tsx`
- Added description property to `ProjectCardResponse.ts`
- Added blank value check in rename project & change project description modals

## Screenshots

<img width="424" height="247" alt="image" src="https://github.com/user-attachments/assets/a102801e-1be5-4d50-b11a-16b29ad4f7e4" />
<img width="801" height="328" alt="image" src="https://github.com/user-attachments/assets/2aac03d5-e345-4cdd-8dd1-60669e60bd7c" />
<img width="865" height="411" alt="image" src="https://github.com/user-attachments/assets/5a400ec5-3598-4dba-ae00-d87332734cda" />


## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project cards now display project descriptions, with clear fallback text when unavailable.
  - Added the ability to view and edit project descriptions from project and file action menus.
  - Descriptions are saved automatically and reflected across project lists and details.
  - Added a reusable description editing dialog.

- **Bug Fixes**
  - Prevented saving blank or whitespace-only project descriptions and names.
  - Project metadata now presents only the most relevant information for owned projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->