### PR TITLE
refactor: Improve module & leaderboard page UIs

### DIFF
--- a/apps/web/src/features/leaderboard/hub/LeaderboardPage.tsx
+++ b/apps/web/src/features/leaderboard/hub/LeaderboardPage.tsx
@@ -105,7 +105,7 @@ function NotQualifiedForLeaderboardPage({
     <div className="layout-grid col-span-full h-full min-h-0 overflow-y-auto px-6 py-6 text-ludo-white lg:px-0">
       <Gutter desktopOnly />
       <div className="col-span-full flex min-h-full min-w-0 items-center justify-center lg:col-span-10">
-        <div className="flex w-full max-w-4xl flex-col items-center gap-7 rounded-xl border border-ludo-border bg-ludo-surface-dim px-5 py-8 text-center shadow-[0_18px_50px_rgba(0,0,0,0.18)] lg:px-10 lg:py-10">
+        <div className="flex w-full max-w-4xl flex-col items-center gap-7 rounded-xl border border-ludo-border bg-ludo-surface-dim px-5 py-8 text-center shadow-[0_7px_0_#262E57] lg:px-10 lg:py-10">
           <div className="flex w-full max-w-xl flex-col items-center gap-4">
             <div className="relative flex h-24 w-24 items-center justify-center rounded-xl border border-ludo-white/10 bg-ludo-surface">
               <Trophy className="size-11 text-ludo-accent-muted" />

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardItemRow.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardItemRow.tsx
@@ -20,18 +20,37 @@ export function LeaderboardItemRow({
   isUser,
 }: LeaderboardItemRowProps) {
   const avatarSrc = getUserAvatar(avatarVersion, avatarIndex);
+  const isPodium = position <= 3;
 
   return (
     <div
       className={cn(
-        "w-full text-lg text-ludo-white h-16 py-1 px-4 rounded-xl border border-ludo-border items-center grid grid-cols-[0.5fr_0.75fr_minmax(0,3fr)_1fr]",
-        isUser && "bg-ludo-surface-hover",
+        "grid h-16 w-full shrink-0 grid-cols-[2rem_2.5rem_minmax(0,1fr)_auto] items-center gap-3 rounded-xl border px-4",
+        isUser
+          ? "border-ludo-accent-muted/50 bg-ludo-surface"
+          : "border-ludo-border bg-ludo-surface-dim",
       )}
     >
-      <p>{position}</p>
-      <Avatar className="h-10 w-10 lg:h-10 lg:w-10" src={avatarSrc} />
-      <p className="min-w-0 truncate">{username}</p>
-      <p className="text-right">{points}</p>
+      <span
+        className={cn(
+          "text-sm font-bold tabular-nums",
+          isPodium ? "text-ludo-accent-muted" : "text-ludo-white-dim",
+        )}
+      >
+        {position}
+      </span>
+      <Avatar className="h-10 w-10 border-2 lg:h-10 lg:w-10" src={avatarSrc} />
+      <p className="min-w-0 truncate text-sm text-ludo-white-bright lg:text-base">
+        {username}
+      </p>
+      <p className="flex items-baseline gap-1 text-right">
+        <span className="text-sm font-bold tabular-nums text-ludo-white-bright lg:text-base">
+          {points}
+        </span>
+        <span className="text-[10px] uppercase tracking-widest text-ludo-white-dim">
+          xp
+        </span>
+      </p>
     </div>
   );
 }

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardList.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardList.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
 
-type LeaderboardListProps = {children: ReactNode;};
+type LeaderboardListProps = { children: ReactNode };
 
-export function LeaderboardList({children}: LeaderboardListProps) {
+export function LeaderboardList({ children }: LeaderboardListProps) {
   return (
-        <div className="scrollable flex-1 w-full flex flex-col gap-4 [scrollbar-gutter:stable] lg:[scrollbar-gutter:auto]">
-            {children}
-        </div>
+    <div className="scrollable flex-1 w-full flex flex-col gap-3 [scrollbar-gutter:stable] lg:[scrollbar-gutter:auto]">
+      {children}
+    </div>
   );
 }

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardPeriodHeader.tsx
@@ -1,4 +1,5 @@
 import { Progress } from "@ludocode/external/ui/progress";
+import { PageMasthead } from "@ludocode/design-system/zones/page-masthead.tsx";
 import {
   formatShortDateRange,
   getDateRangeProgress,
@@ -20,23 +21,21 @@ export function LeaderboardPeriodHeader({
   const progress = getDateRangeProgress(start, end);
 
   return (
-    <section className="shrink-0 rounded-xl border border-ludo-border bg-ludo-surface-dim p-3 lg:p-4">
-      <div className="flex flex-col gap-1.5 lg:flex-row lg:items-center lg:justify-between lg:gap-3">
-        <h1 className="text-lg font-bold text-ludo-white-bright lg:text-xl">
-          Weekly Leaderboard
-        </h1>
-        <div className="flex items-center gap-1.5 text-xs text-ludo-white-dim lg:gap-2 lg:text-xs">
-          <CalendarDays className="size-3.5 text-ludo-accent-muted lg:size-4" />
-          <span>{formatShortDateRange(start, end)}</span>
+    <PageMasthead
+      className="shrink-0"
+      eyebrow="Weekly ranking"
+      title="Leaderboard"
+      subtitle="Earn XP this week to climb the leaderboard"
+    >
+      <div className="flex w-full flex-col gap-2 rounded-lg border border-ludo-border bg-ludo-surface-dim px-4 py-3 lg:w-60">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="size-3.5 shrink-0 text-ludo-accent-muted" />
+          <span className="truncate text-xs text-ludo-white">
+            {formatShortDateRange(start, end)}
+          </span>
         </div>
+        <Progress className="h-1.5 bg-ludo-background" value={progress} />
       </div>
-
-      <div className="mt-2.5 lg:mt-4">
-        <Progress
-          className="h-2 border border-ludo-border bg-ludo-background/60"
-          value={progress}
-        />
-      </div>
-    </section>
+    </PageMasthead>
   );
 }

--- a/apps/web/src/features/leaderboard/hub/components/LeaderboardPodium.tsx
+++ b/apps/web/src/features/leaderboard/hub/components/LeaderboardPodium.tsx
@@ -46,7 +46,7 @@ function PodiumPlayer({ currentUserId, user, rank }: PodiumPlayerProps) {
   const displayName = user?.displayName ?? "Unclaimed";
   const points = user?.xp ? user.xp.toString() : "--";
 
-  const ownStyle = currentUserId == user?.userId ? "bg-ludo-accent" : ""
+  const ownStyle = currentUserId == user?.userId ? "bg-ludo-accent" : "";
 
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-1 lg:gap-2">
@@ -63,7 +63,7 @@ function PodiumPlayer({ currentUserId, user, rank }: PodiumPlayerProps) {
         className={cn(
           "flex flex-col items-center justify-center rounded-t-xl bg-ludo-surface",
           podiumHeights[rank],
-          ownStyle
+          ownStyle,
         )}
       >
         <p

--- a/apps/web/src/features/modules/hooks/useLessonButton.tsx
+++ b/apps/web/src/features/modules/hooks/useLessonButton.tsx
@@ -13,6 +13,15 @@ type Args = {
   isCurrent: boolean;
 };
 
+export function getLessonStatus(
+  lesson: LudoLesson,
+  isCurrent: boolean,
+): LessonStatus {
+  if (isCurrent) return "DEFAULT";
+  if (lesson.isCompleted) return "MASTERED";
+  return "LOCKED";
+}
+
 export function useLessonButton({
   lesson,
   courseId,
@@ -20,16 +29,9 @@ export function useLessonButton({
   isCurrent,
 }: Args) {
   const router = useRouter();
-  const isCompleted = lesson.isCompleted;
   const isLocked = !lesson.isCompleted && !isCurrent;
 
-  const lessonType: LessonStatus = isCurrent
-    ? "DEFAULT"
-    : isCompleted
-      ? "MASTERED"
-      : isLocked
-        ? "LOCKED"
-        : "DEFAULT";
+  const lessonType = getLessonStatus(lesson, isCurrent);
 
   const goToLesson = () => {
     if (isLocked) return;

--- a/apps/web/src/features/modules/hub/ModulePage.tsx
+++ b/apps/web/src/features/modules/hub/ModulePage.tsx
@@ -7,6 +7,7 @@ import { ModuleNavigator } from "./navigator/ModuleNavigator.tsx";
 import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
 import { getRouteApi, useRouter } from "@tanstack/react-router";
 import { ModulePath } from "./path/ModulePath.tsx";
+import { ModulePathHeader } from "./path/ModulePathHeader.tsx";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
 
 type ModulePageProps = {
@@ -24,13 +25,13 @@ export function ModulePage({
   moduleProgress,
   className,
 }: ModulePageProps) {
-  if (!course) return null;
-
-  const { id: courseId, title: courseTitle } = course;
-
   const routeApi = getRouteApi("/app/_hub/learn/$courseId/$moduleId");
   const router = useRouter();
   const { moduleId } = routeApi.useParams();
+
+  if (!course) return null;
+
+  const { id: courseId, title: courseTitle } = course;
 
   const selectModule = (selectedModuleId: string) => {
     if (moduleId === selectedModuleId) return;
@@ -43,6 +44,8 @@ export function ModulePage({
 
   const i = modules.findIndex((m) => m.id === moduleId);
   const nextModule = i >= 0 ? modules[i + 1] : undefined;
+  const currentModule = i >= 0 ? modules[i] : undefined;
+  const completedLessons = lessons.filter((l) => l.isCompleted).length;
 
   return (
     <div
@@ -51,7 +54,16 @@ export function ModulePage({
         className,
       )}
     >
-      <div className="w-60 flex flex-col lg:gap-8 items-center lg:px-0 min-w-0">
+      <div className="w-72 lg:w-80 max-w-full flex flex-col gap-4 lg:gap-6 items-center lg:px-0 min-w-0">
+        {currentModule && (
+          <ModulePathHeader
+            moduleTitle={currentModule.title}
+            moduleIndex={i + 1}
+            moduleCount={modules.length}
+            completedLessons={completedLessons}
+            totalLessons={lessons.length}
+          />
+        )}
         <ModulePath
           modulesLength={modules.length}
           lessons={lessons}

--- a/apps/web/src/features/modules/hub/path/ModulePath.tsx
+++ b/apps/web/src/features/modules/hub/path/ModulePath.tsx
@@ -1,6 +1,9 @@
 import { LudoPath } from "@ludocode/design-system/widgets/ludo-path.tsx";
 import type { LudoLesson } from "@ludocode/types";
-import { useLessonButton } from "@/features/modules/hooks/useLessonButton.tsx";
+import {
+  getLessonStatus,
+  useLessonButton,
+} from "@/features/modules/hooks/useLessonButton.tsx";
 import { PathPopover } from "./PathPopover.tsx";
 import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
 import { router } from "@/main.tsx";
@@ -42,7 +45,20 @@ export function ModulePath({
   return (
     <LudoPath className="pb-6">
       {lessonRows.map(({ lesson, rowIndex, isGuided }) => (
-        <LudoPath.Row key={lesson.id} index={rowIndex} fullSpan={isGuided}>
+        <LudoPath.Row
+          key={lesson.id}
+          index={rowIndex}
+          fullSpan={isGuided}
+          isCurrent={currentLessonId === lesson.id}
+          label={
+            <LudoPath.Label
+              step={rowIndex + 1}
+              title={lesson.title}
+              state={getLessonStatus(lesson, currentLessonId === lesson.id)}
+              isCurrent={currentLessonId === lesson.id}
+            />
+          }
+        >
           <ModulePathButton
             lesson={lesson}
             courseId={courseId}
@@ -52,7 +68,7 @@ export function ModulePath({
         </LudoPath.Row>
       ))}
       {nextModuleId && (
-        <LudoPath.Row className="mt-10" index={normalLessonCount}>
+        <LudoPath.Row className="mt-6" index={normalLessonCount} fullSpan>
           <LudoPath.NextButton
             title={nextModuleTitle}
             dataTestId={testIds.module.nextButton}

--- a/apps/web/src/features/modules/hub/path/ModulePath.tsx
+++ b/apps/web/src/features/modules/hub/path/ModulePath.tsx
@@ -94,12 +94,12 @@ export function ModulePath({
       ))}
       {nextModuleId && (
         <LudoPath.Row
-          className="mt-6"
           index={normalLessonCount}
           fullSpan
           railAbove={moduleComplete ? "lit" : "dim"}
         >
           <LudoPath.NextButton
+            className="mt-6"
             title={nextModuleTitle}
             dataTestId={testIds.module.nextButton}
             onClick={() =>

--- a/apps/web/src/features/modules/hub/path/ModulePath.tsx
+++ b/apps/web/src/features/modules/hub/path/ModulePath.tsx
@@ -1,4 +1,7 @@
-import { LudoPath } from "@ludocode/design-system/widgets/ludo-path.tsx";
+import {
+  LudoPath,
+  type PathRail,
+} from "@ludocode/design-system/widgets/ludo-path.tsx";
 import type { LudoLesson } from "@ludocode/types";
 import {
   getLessonStatus,
@@ -27,29 +30,51 @@ export function ModulePath({
   nextModuleId,
   nextModuleTitle,
 }: ModulePathProps) {
+  const isReached = (lesson: LudoLesson) =>
+    lesson.isCompleted || lesson.id === currentLessonId;
+
+  const moduleComplete = lessons.every((lesson) => lesson.isCompleted);
+
   let normalLessonCount = 0;
-  const lessonRows = lessons.map((lesson) => {
+  const lessonRows = lessons.map((lesson, lessonIndex) => {
     const isGuided = lesson.lessonType === "GUIDED";
     const rowIndex = normalLessonCount;
     if (!isGuided) {
       normalLessonCount += 1;
     }
 
+    const nextLesson = lessons[lessonIndex + 1];
+
+    const railAbove: PathRail =
+      lessonIndex === 0 ? "none" : isReached(lesson) ? "lit" : "dim";
+
+    const railBelow: PathRail = nextLesson
+      ? isReached(nextLesson)
+        ? "lit"
+        : "dim"
+      : nextModuleId
+        ? moduleComplete
+          ? "lit"
+          : "dim"
+        : "none";
+
     return {
       lesson,
       rowIndex,
       isGuided,
+      railAbove,
+      railBelow,
     };
   });
 
   return (
     <LudoPath className="pb-6">
-      {lessonRows.map(({ lesson, rowIndex, isGuided }) => (
+      {lessonRows.map(({ lesson, rowIndex, isGuided, ...rail }) => (
         <LudoPath.Row
           key={lesson.id}
           index={rowIndex}
           fullSpan={isGuided}
-          isCurrent={currentLessonId === lesson.id}
+          {...rail}
           label={
             <LudoPath.Label
               step={rowIndex + 1}
@@ -68,7 +93,12 @@ export function ModulePath({
         </LudoPath.Row>
       ))}
       {nextModuleId && (
-        <LudoPath.Row className="mt-6" index={normalLessonCount} fullSpan>
+        <LudoPath.Row
+          className="mt-6"
+          index={normalLessonCount}
+          fullSpan
+          railAbove={moduleComplete ? "lit" : "dim"}
+        >
           <LudoPath.NextButton
             title={nextModuleTitle}
             dataTestId={testIds.module.nextButton}

--- a/apps/web/src/features/modules/hub/path/ModulePathHeader.tsx
+++ b/apps/web/src/features/modules/hub/path/ModulePathHeader.tsx
@@ -1,0 +1,30 @@
+type ModulePathHeaderProps = {
+  moduleTitle: string;
+  moduleIndex: number;
+  moduleCount: number;
+  completedLessons: number;
+  totalLessons: number;
+};
+
+export function ModulePathHeader({
+  moduleTitle,
+  moduleIndex,
+  moduleCount,
+  completedLessons,
+  totalLessons,
+}: ModulePathHeaderProps) {
+  return (
+    <header className="sticky top-0 z-20 flex w-full flex-col items-center gap-1 bg-ludo-background pb-3 pt-1 text-center">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-ludo-accent-muted">
+        Module {moduleIndex} of {moduleCount}
+      </span>
+      <h1 className="text-xl font-bold leading-tight tracking-tight text-ludo-white-bright">
+        {moduleTitle}
+      </h1>
+      <span className="text-xs tabular-nums text-ludo-white-dim">
+        {completedLessons}/{totalLessons} lessons complete
+      </span>
+      <div className="mt-3 h-px w-full bg-ludo-surface" />
+    </header>
+  );
+}

--- a/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
+++ b/apps/web/src/features/project/workbench/zones/WorkbenchTreePane.tsx
@@ -18,7 +18,6 @@ import { qo } from "@/queries/definitions/queries.ts";
 import { useUserPreferencesContext } from "@/features/user/context/useUserPreferenceContext.tsx";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
 import { useFeatureEnabledCheck } from "@/features/auth/hooks/useFeatureEnabledCheck.tsx";
-import { Play } from "lucide-react";
 import {
   Tooltip,
   TooltipTrigger,
@@ -120,8 +119,8 @@ export function WorkbenchTreePane({
                     isEntryFile ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <span className="flex mr-1 items-center">
-                            <Play className="h-3 w-3 fill-ludo-amber-alt text-ludo-amber-alt" />
+                          <span className="mr-1 rounded-full border border-ludo-border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-widest text-ludo-white-dim">
+                            entry
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" sideOffset={6}>
@@ -146,7 +145,7 @@ export function WorkbenchTreePane({
                         trigger={
                           <div
                             onClick={(e) => e.stopPropagation()}
-                            className="p-1 rounded-full hover:bg-ludo-accent-muted"
+                            className="rounded-md p-1 text-ludo-white-dim hover:bg-ludo-background hover:text-ludo-white-bright"
                           >
                             <HeroIcon
                               iconName="EllipsisVerticalIcon"

--- a/packages/design-system/widgets/ludo-file-tree.tsx
+++ b/packages/design-system/widgets/ludo-file-tree.tsx
@@ -41,7 +41,13 @@ function Root({
     <FileTreeContext.Provider
       value={{ selectedId, onSelect, rename, deleteItem, readOnly }}
     >
-      <div className="flex flex-col gap-1">{children}</div>
+      <div className="relative flex flex-col gap-0.5 pl-3">
+        <span
+          aria-hidden
+          className="absolute left-0 top-[1.125rem] bottom-[1.125rem] w-0.5 rounded-full bg-ludo-surface"
+        />
+        {children}
+      </div>
     </FileTreeContext.Provider>
   );
 }
@@ -59,26 +65,46 @@ function Item({ id, name, icon, actions, indicator, dataTestId }: ItemProps) {
   const { selectedId, onSelect } = useFileTree();
   const isSelected = selectedId === id;
 
+  const dotIndex = name.lastIndexOf(".");
+  const baseName = dotIndex > 0 ? name.slice(0, dotIndex) : name;
+  const extension = dotIndex > 0 ? name.slice(dotIndex) : "";
+
   return (
     <button
       data-testid={dataTestId}
       onClick={() => onSelect?.(id)}
       className={cn(
-        "flex w-full hover:cursor-pointer justify-between px-2 py-1 rounded-lg items-center",
+        "group relative flex h-9 w-full min-w-0 items-center justify-between gap-2 overflow-hidden rounded-lg pl-3 pr-2 transition-colors hover:cursor-pointer",
         isSelected
-          ? "bg-ludo-accent-muted/70"
-          : "hover:bg-ludo-accent-muted/50",
+          ? "bg-ludo-surface text-ludo-white-bright"
+          : "text-ludo-white hover:bg-ludo-surface/60",
       )}
     >
-      <div className="flex gap-3 items-center">
-        {icon}
-        <span className="text-sm">{name}</span>
-      </div>
+      {isSelected && (
+        <span
+          aria-hidden
+          className="absolute bottom-1 left-0 top-1 w-0.5 rounded-full bg-ludo-accent-muted"
+        />
+      )}
 
-      <div className="flex items-center gap-1">
+      <span className="flex min-w-0 items-center gap-2.5">
+        {icon}
+        <span className="min-w-0 truncate text-sm">
+          {baseName}
+          {extension && (
+            <span
+              className={isSelected ? "text-ludo-white" : "text-ludo-white-dim"}
+            >
+              {extension}
+            </span>
+          )}
+        </span>
+      </span>
+
+      <span className="flex shrink-0 items-center gap-1">
         {indicator}
         {actions}
-      </div>
+      </span>
     </button>
   );
 }

--- a/packages/design-system/widgets/ludo-path.tsx
+++ b/packages/design-system/widgets/ludo-path.tsx
@@ -16,14 +16,12 @@ function LudoPathRoot({ children, className }: LudoPathProps) {
         className,
       )}
     >
-      <span
-        aria-hidden
-        className="absolute inset-y-4 left-1/2 w-0.5 -translate-x-1/2 rounded-full bg-ludo-surface"
-      />
       {children}
     </div>
   );
 }
+
+export type PathRail = "none" | "dim" | "lit";
 
 type RowProps = {
   children: ReactNode;
@@ -31,8 +29,12 @@ type RowProps = {
   className?: string;
   fullSpan?: boolean;
   label?: ReactNode;
-  isCurrent?: boolean;
+  railAbove?: PathRail;
+  railBelow?: PathRail;
 };
+
+const railColor = (state: PathRail) =>
+  state === "lit" ? "bg-ludo-accent-muted" : "bg-ludo-surface";
 
 function Row({
   children,
@@ -40,8 +42,32 @@ function Row({
   className,
   fullSpan = false,
   label,
-  isCurrent = false,
+  railAbove = "none",
+  railBelow = "none",
 }: RowProps) {
+  const rail = (
+    <>
+      {railAbove !== "none" && (
+        <span
+          aria-hidden
+          className={cn(
+            "absolute left-1/2 -top-3 h-[calc(50%+0.75rem)] w-0.5 -translate-x-1/2 rounded-full",
+            railColor(railAbove),
+          )}
+        />
+      )}
+      {railBelow !== "none" && (
+        <span
+          aria-hidden
+          className={cn(
+            "absolute left-1/2 top-1/2 -bottom-3 w-0.5 -translate-x-1/2 rounded-full",
+            railColor(railBelow),
+          )}
+        />
+      )}
+    </>
+  );
+
   if (fullSpan) {
     return (
       <div
@@ -50,12 +76,16 @@ function Row({
           className,
         )}
       >
+        {rail}
         {children}
       </div>
     );
   }
 
   const nodeOnRight = index % 2 === 0;
+
+  const stubState: PathRail =
+    railAbove === "lit" || railBelow === "lit" ? "lit" : "dim";
 
   const node = (
     <div
@@ -68,7 +98,7 @@ function Row({
         aria-hidden
         className={cn(
           "absolute top-1/2 h-0.5 w-2 -translate-y-1/2",
-          isCurrent ? "bg-ludo-accent-muted" : "bg-ludo-surface",
+          railColor(stubState),
           nodeOnRight ? "left-0" : "right-0",
         )}
       />
@@ -94,6 +124,7 @@ function Row({
         className,
       )}
     >
+      {rail}
       {nodeOnRight ? side : node}
       {nodeOnRight ? node : side}
     </div>

--- a/packages/design-system/widgets/ludo-path.tsx
+++ b/packages/design-system/widgets/ludo-path.tsx
@@ -12,10 +12,14 @@ function LudoPathRoot({ children, className }: LudoPathProps) {
   return (
     <div
       className={cn(
-        "w-60 flex flex-col gap-4 lg:gap-8 items-center lg:px-0 min-w-0",
+        "relative w-full max-w-72 lg:max-w-80 flex flex-col gap-4 lg:gap-6 items-center min-w-0",
         className,
       )}
     >
+      <span
+        aria-hidden
+        className="absolute inset-y-4 left-1/2 w-0.5 -translate-x-1/2 rounded-full bg-ludo-surface"
+      />
       {children}
     </div>
   );
@@ -26,36 +30,111 @@ type RowProps = {
   index: number;
   className?: string;
   fullSpan?: boolean;
+  label?: ReactNode;
+  isCurrent?: boolean;
 };
 
-function Row({ children, index, className, fullSpan = false }: RowProps) {
-  const position = index % 2 === 0 ? "flex-row-reverse" : "flex-row";
+function Row({
+  children,
+  index,
+  className,
+  fullSpan = false,
+  label,
+  isCurrent = false,
+}: RowProps) {
+  if (fullSpan) {
+    return (
+      <div
+        className={cn(
+          "relative z-10 w-full min-w-0 flex items-center justify-center",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  const nodeOnRight = index % 2 === 0;
+
+  const node = (
+    <div
+      className={cn(
+        "relative flex w-1/2 min-w-0 items-center",
+        nodeOnRight ? "justify-start pl-2" : "justify-end pr-2",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "absolute top-1/2 h-0.5 w-2 -translate-y-1/2",
+          isCurrent ? "bg-ludo-accent-muted" : "bg-ludo-surface",
+          nodeOnRight ? "left-0" : "right-0",
+        )}
+      />
+      {children}
+    </div>
+  );
+
+  const side = (
+    <div
+      className={cn(
+        "flex w-1/2 min-w-0 items-center",
+        nodeOnRight ? "justify-end pr-3 text-right" : "justify-start pl-3",
+      )}
+    >
+      {label}
+    </div>
+  );
 
   return (
     <div
       className={cn(
-        "w-full min-w-0 relative flex items-center",
-        fullSpan ? "justify-center" : position,
+        "relative z-10 w-full min-w-0 flex items-center",
         className,
       )}
     >
-      {children}
+      {nodeOnRight ? side : node}
+      {nodeOnRight ? node : side}
     </div>
   );
 }
 
-function CurrentRing() {
+type LabelProps = {
+  step: number;
+  title: string;
+  state: LessonStatus;
+  isCurrent?: boolean;
+};
+
+function Label({ step, title, state, isCurrent = false }: LabelProps) {
+  const tone =
+    state === "LOCKED"
+      ? "text-ludo-white-disabled"
+      : isCurrent
+        ? "text-ludo-white-bright"
+        : "text-ludo-white";
+
   return (
-    <span
-      aria-hidden
-      className={cn(
-        "absolute pointer-events-none rounded-[14px] border-2 border-ludo-accent-muted",
-        "-top-1.5 -left-1.5 -right-1.5 -bottom-[13px]",
-        "group-data-[state=open]:-bottom-1.5",
-      )}
-    />
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <span
+        className={cn(
+          "text-[10px] font-semibold uppercase tracking-widest tabular-nums",
+          isCurrent ? "text-ludo-accent-muted" : "text-ludo-white-dim",
+        )}
+      >
+        {isCurrent ? "Current" : String(step).padStart(2, "0")}
+      </span>
+      <span
+        className={cn("line-clamp-2 text-xs font-semibold leading-snug", tone)}
+      >
+        {title}
+      </span>
+    </div>
   );
 }
+
+const currentOutline = "ring-2 ring-ludo-accent-muted";
 
 const pathIcon =
   "h-10 w-10 shrink-0 transition-[filter] duration-100 group-data-[state=open]:drop-shadow-none";
@@ -68,14 +147,20 @@ const carvedIcon =
 
 function PathStateIcon({ state }: { state: LessonStatus }) {
   if (state === "LOCKED") {
-    return <LockIcon className={cn(pathIcon, carvedIcon, "text-ludo-background")} />;
+    return (
+      <LockIcon className={cn(pathIcon, carvedIcon, "text-ludo-background")} />
+    );
   }
 
   const Icon = state === "DEFAULT" ? PlayIcon : StarIcon;
 
   return (
     <Icon
-      className={cn(pathIcon, raisedIcon, "fill-current text-ludo-accent-muted")}
+      className={cn(
+        pathIcon,
+        raisedIcon,
+        "fill-current text-ludo-accent-muted",
+      )}
     />
   );
 }
@@ -95,7 +180,8 @@ const Button = React.forwardRef<HTMLButtonElement, PathButtonProps>(
         selected={isCurrent}
         clickable={false}
         className={cn(
-          "group relative w-20 hover:cursor-pointer h-20",
+          "group relative w-20 hover:cursor-pointer h-20 shrink-0",
+          isCurrent && currentOutline,
           className,
         )}
         {...props}
@@ -103,7 +189,6 @@ const Button = React.forwardRef<HTMLButtonElement, PathButtonProps>(
         <div className="absolute inset-0 overflow-hidden rounded-lg pointer-events-none">
           <CompletionRibbon lessonState={state} />
         </div>
-        {isCurrent && <CurrentRing />}
         <PathStateIcon state={state} />
       </LudoButton>
     );
@@ -126,7 +211,8 @@ const GuidedButton = React.forwardRef<HTMLButtonElement, GuidedButtonProps>(
         selected={isCurrent}
         clickable={false}
         className={cn(
-          "group relative w-full flex justify-center items-center hover:cursor-pointer my-4 h-20 p-3",
+          "group relative w-full flex-col gap-1 justify-center items-center hover:cursor-pointer my-4 h-20 px-4",
+          isCurrent && currentOutline,
           className,
         )}
         {...props}
@@ -135,10 +221,18 @@ const GuidedButton = React.forwardRef<HTMLButtonElement, GuidedButtonProps>(
           <CompletionRibbon lessonState={state} />
         </div>
 
-        {isCurrent && <CurrentRing />}
-
-        <p className="text-ludo-accent-muted text-sm text-center font-semibold uppercase tracking-widest">
-          GUIDED PROJECT
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-ludo-accent-muted">
+          {isCurrent ? "Guided project · now" : "Guided project"}
+        </p>
+        <p
+          className={cn(
+            "line-clamp-2 text-sm font-semibold leading-snug",
+            state === "LOCKED"
+              ? "text-ludo-white-dim"
+              : "text-ludo-white-bright",
+          )}
+        >
+          {title}
         </p>
       </LudoButton>
     );
@@ -161,12 +255,14 @@ const NextButton = React.forwardRef<HTMLButtonElement, NextButtonProps>(
         variant="default"
         onClick={() => onClick?.()}
         className={cn(
-          "relative w-full hover:cursor-pointer h-16 gap-3 flex items-center justify-center",
+          "relative w-full hover:cursor-pointer h-16 gap-3 flex items-center justify-center px-4",
           className,
         )}
         {...props}
       >
-        <span className="font-semibold tracking-wide">{title ?? "Next"}</span>
+        <span className="truncate font-semibold tracking-wide">
+          {title ?? "Next"}
+        </span>
         <ArrowRightIcon className="h-5 w-5 shrink-0" />
       </LudoButton>
     );
@@ -178,6 +274,7 @@ type LudoPathComponent = React.FC<LudoPathProps> & {
   Button: typeof Button;
   GuidedButton: typeof GuidedButton;
   NextButton: typeof NextButton;
+  Label: typeof Label;
 };
 
 export const LudoPath = Object.assign(LudoPathRoot, {
@@ -185,4 +282,5 @@ export const LudoPath = Object.assign(LudoPathRoot, {
   NextButton,
   Button,
   GuidedButton,
+  Label,
 }) as LudoPathComponent;

--- a/packages/design-system/widgets/ludo-path.tsx
+++ b/packages/design-system/widgets/ludo-path.tsx
@@ -12,7 +12,7 @@ function LudoPathRoot({ children, className }: LudoPathProps) {
   return (
     <div
       className={cn(
-        "relative w-full max-w-72 lg:max-w-80 flex flex-col gap-4 lg:gap-6 items-center min-w-0",
+        "relative w-full max-w-72 lg:max-w-80 flex flex-col items-center min-w-0",
         className,
       )}
     >
@@ -51,7 +51,7 @@ function Row({
         <span
           aria-hidden
           className={cn(
-            "absolute left-1/2 -top-3 h-[calc(50%+0.75rem)] w-0.5 -translate-x-1/2 rounded-full",
+            "absolute left-1/2 top-0 h-1/2 w-0.5 -translate-x-1/2",
             railColor(railAbove),
           )}
         />
@@ -60,7 +60,7 @@ function Row({
         <span
           aria-hidden
           className={cn(
-            "absolute left-1/2 top-1/2 -bottom-3 w-0.5 -translate-x-1/2 rounded-full",
+            "absolute left-1/2 top-1/2 bottom-0 w-0.5 -translate-x-1/2",
             railColor(railBelow),
           )}
         />
@@ -72,7 +72,7 @@ function Row({
     return (
       <div
         className={cn(
-          "relative z-10 w-full min-w-0 flex items-center justify-center",
+          "relative z-10 w-full min-w-0 flex items-center justify-center py-2 lg:py-3",
           className,
         )}
       >
@@ -120,7 +120,7 @@ function Row({
   return (
     <div
       className={cn(
-        "relative z-10 w-full min-w-0 flex items-center",
+        "relative z-10 w-full min-w-0 flex items-center py-2 lg:py-3",
         className,
       )}
     >

--- a/packages/types/Project/ProjectFileSnapshot.ts
+++ b/packages/types/Project/ProjectFileSnapshot.ts
@@ -25,7 +25,7 @@ export const Languages: Record<LanguageKey, LanguageMetadata> = {
     languageId: 1,
     name: "javascript",
     extension: ".js",
-    base: "web",
+    base: "script",
     iconName: "Javascript",
     initialScript: `console.log("Hello world");`,
     webAllowed: true,
@@ -42,7 +42,7 @@ export const Languages: Record<LanguageKey, LanguageMetadata> = {
     languageId: 3,
     name: "html",
     extension: ".html",
-    base: "web",
+    base: "page",
     iconName: "HTML",
     initialScript: `<!DOCTYPE html>
 <html>
@@ -61,7 +61,7 @@ export const Languages: Record<LanguageKey, LanguageMetadata> = {
     languageId: 4,
     name: "css",
     extension: ".css",
-    base: "web",
+    base: "style",
     iconName: "CSS",
     initialScript: `body { margin: 0; }`,
     webAllowed: true,


### PR DESCRIPTION
## Summary
This PR changes the UI of the module and leaderboard pages, and also the file tree UI. It adds headers to all hub pages so they look consistent, and adds tree-style connections between the lesson buttons in the module path. It hopefully improves UX since the module page now clearly shows the path and current lesson,

## Changes
- Changed visual style of the `LudoFileTree` to be less flat and feel more integrated
- Added a tree style rail to the lesson path
  - The rail lights up until the point of the current lesson to show the completion in the module
- Added a header to the leaderboard and module pages

## Screenshots
<img width="401" height="727" alt="image" src="https://github.com/user-attachments/assets/81b2c7f7-5701-4226-bf88-183214fd539f" />
<img width="400" height="726" alt="image" src="https://github.com/user-attachments/assets/51143dc8-394d-4015-8eaf-aca2ced07839" />

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned leaderboard header with weekly ranking details, date range, progress panel, and highlighted top-three ranks.
  - Added module headers showing position, lesson progress, and completion status.
  - Enhanced module paths with lesson labels, progress rails, current-state highlighting, and next-module navigation.
  - Added clearer project file-tree entry badges, indentation, guides, selection states, and file-extension styling.

- **Style**
  - Refined leaderboard spacing, shadows, surfaces, borders, and XP labels.
  - Updated path, button, and file-tree layouts for improved responsive presentation.
  - Updated language metadata labels for JavaScript, HTML, and CSS files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->