### PR TITLE
feat: Add module descriptions and arrange module page nicely

### DIFF
--- a/apps/admin/src/features/curriculum/CurriculumPage.tsx
+++ b/apps/admin/src/features/curriculum/CurriculumPage.tsx
@@ -65,6 +65,7 @@ export function CurriculumPage({}: CurriculumPageProps) {
       modules: curriculumSnap.modules.map((m) => ({
         id: m.id,
         title: m.title,
+        description: m.description ?? null,
         lessons: m.lessons.map((l) => ({
           id: l.id,
           title: l.title,
@@ -268,6 +269,7 @@ export function CurriculumPage({}: CurriculumPageProps) {
                             modules: freshSnap.modules.map((m) => ({
                               id: m.id,
                               title: m.title,
+                              description: m.description ?? null,
                               lessons: m.lessons.map((l) => ({
                                 id: l.id,
                                 title: l.title,

--- a/apps/admin/src/features/curriculum/CurriculumPage.tsx
+++ b/apps/admin/src/features/curriculum/CurriculumPage.tsx
@@ -9,7 +9,10 @@ import {
   type CurriculumDraftLesson,
 } from "@ludocode/types";
 import { useAppForm } from "./types";
-import { useUpdateCourse, useUpdateYamlCourse } from "@/queries/mutations/curriculumMutations";
+import {
+  useUpdateCourse,
+  useUpdateYamlCourse,
+} from "@/queries/mutations/curriculumMutations";
 import { CurriculumPreview } from "@/features/curriculum/navigator/preview/CurriculumPreview.tsx";
 import { CurriculumEditor } from "@/features/curriculum/navigator/editor/CurriculumEditor.tsx";
 import { LessonDetailPreview } from "@/features/curriculum/detail/preview/LessonDetailPreview.tsx";
@@ -19,10 +22,16 @@ import { adminNavigation } from "@/constants/adminNavigation";
 import { adminApi } from "@/constants/api/adminApi";
 import { DeleteDialog } from "@ludocode/design-system/templates/dialog/delete-dialog";
 import { RenameDialog } from "@ludocode/design-system/templates/dialog/rename-dialog";
+import { DescriptionDialog } from "@ludocode/design-system/templates/dialog/description-dialog";
 import { CourseStatusBadge } from "@/features/curriculum/components/CourseStatusBadge.tsx";
-import { useChangeCourseStatus, useChangeCourseTitle, useDeleteCourse } from "@/queries/mutations/courseMutations";
+import {
+  useChangeCourseDescription,
+  useChangeCourseStatus,
+  useChangeCourseTitle,
+  useDeleteCourse,
+} from "@/queries/mutations/courseMutations";
 import type { CourseStatus } from "@ludocode/types";
-import { Archive, Globe, Pencil, TrashIcon } from "lucide-react";
+import { AlignLeft, Archive, Globe, Pencil, TrashIcon } from "lucide-react";
 
 type CurriculumPageProps = {};
 
@@ -40,6 +49,8 @@ export function CurriculumPage({}: CurriculumPageProps) {
 
   const courseLanguage = courses.find((c) => c.id == courseId)?.codeLanguage;
 
+  const courseDescription = courses.find((c) => c.id === courseId)?.description;
+
   const courseIcon = courses.find((c) => c.id === courseId)?.courseIcon;
 
   const courseStatus: CourseStatus =
@@ -48,6 +59,9 @@ export function CurriculumPage({}: CurriculumPageProps) {
   const changeCourseStatus = useChangeCourseStatus({ courseId });
   const deleteCourseMutation = useDeleteCourse({ courseId });
   const changeCourseTitleMutation = useChangeCourseTitle({ courseId });
+  const changeCourseDescriptionMutation = useChangeCourseDescription({
+    courseId,
+  });
 
   const [isEditing, setIsEditing] = useState(false);
 
@@ -149,6 +163,12 @@ export function CurriculumPage({}: CurriculumPageProps) {
               <CourseStatusBadge status={courseStatus} />
             </div>
 
+            {courseDescription && (
+              <p className="text-ludo-white-dim max-w-2xl text-sm">
+                {courseDescription}
+              </p>
+            )}
+
             <div className="flex items-center gap-3">
               <RenameDialog
                 itemName={courseName}
@@ -165,6 +185,24 @@ export function CurriculumPage({}: CurriculumPageProps) {
                   Rename
                 </button>
               </RenameDialog>
+
+              <DescriptionDialog
+                itemDescription={courseDescription ?? ""}
+                itemCategory="Course"
+                onSubmit={(_old, newDescription) => {
+                  changeCourseDescriptionMutation.mutate({
+                    description: newDescription,
+                  });
+                }}
+              >
+                <button
+                  type="button"
+                  className="flex items-center gap-2 rounded-md border border-ludo-accent-muted/40 bg-transparent px-4 py-2 text-sm font-medium text-ludo-white transition hover:bg-ludo-surface disabled:opacity-50"
+                >
+                  <AlignLeft className="h-4 w-4" />
+                  {courseDescription ? "Edit description" : "Add description"}
+                </button>
+              </DescriptionDialog>
 
               {courseStatus === "DRAFT" && (
                 <>

--- a/apps/admin/src/features/curriculum/navigator/editor/EditorModule.tsx
+++ b/apps/admin/src/features/curriculum/navigator/editor/EditorModule.tsx
@@ -1,4 +1,5 @@
 import { LudoInput } from "@ludocode/design-system/primitives/input.tsx";
+import { Textarea } from "@ludocode/external/ui/textarea.tsx";
 import type { CurriculumDraft, LanguageKey } from "@ludocode/types";
 import { withForm } from "../../types.ts";
 
@@ -55,6 +56,24 @@ export const EditorModule = withForm({
               disabled={!canDelete}
             />
           )}
+        </div>
+
+        <div className="border-b-3 border-b-ludo-border px-4 py-3">
+          <form.Field
+            name={`modules[${moduleIndex}].description`}
+            children={(field) => (
+              <Textarea
+                value={field.state.value ?? ""}
+                onChange={(e) =>
+                  field.handleChange(
+                    e.target.value.length ? e.target.value : null,
+                  )
+                }
+                placeholder="Module description shown to learners..."
+                className="bg-ludo-background border-transparent text-ludo-white-bright placeholder:text-ludoGray focus:ring-0 focus-visible:ring-0 min-h-16 resize-none"
+              />
+            )}
+          />
         </div>
 
         <SortableLessonContainer

--- a/apps/admin/src/features/curriculum/navigator/preview/CurriculumPreview.tsx
+++ b/apps/admin/src/features/curriculum/navigator/preview/CurriculumPreview.tsx
@@ -86,6 +86,7 @@ export function CurriculumPreview({
             onLessonClick={onLessonClick}
             onLessonNavigate={onLessonNavigate}
             title={module.title}
+            description={module.description}
             lessons={module.lessons}
           />
         ))}

--- a/apps/admin/src/features/curriculum/navigator/preview/ModulePreviewItem.tsx
+++ b/apps/admin/src/features/curriculum/navigator/preview/ModulePreviewItem.tsx
@@ -6,6 +6,7 @@ import { LessonPreviewItem } from "./LessonPreviewItem.tsx";
 
 type ModulePreviewItemProps = {
   title: string;
+  description?: string | null;
   lessons: CurriculumDraftLessons;
   onLessonClick: (lesson: CurriculumDraftLesson) => void;
   onLessonNavigate?: (lesson: CurriculumDraftLesson) => void;
@@ -14,6 +15,7 @@ type ModulePreviewItemProps = {
 
 export function ModulePreviewItem({
   title,
+  description,
   lessons,
   onLessonClick,
   onLessonNavigate,
@@ -22,6 +24,9 @@ export function ModulePreviewItem({
   return (
     <div className="flex flex-col">
       <p>{title}</p>
+      {description && (
+        <p className="text-ludo-white-dim text-xs mt-1">{description}</p>
+      )}
       <div className="w-full flex flex-col gap-2 p-4">
         {lessons.map((lesson) => (
           <LessonPreviewItem

--- a/apps/admin/src/features/curriculum/templates.ts
+++ b/apps/admin/src/features/curriculum/templates.ts
@@ -12,6 +12,7 @@ import {
 export const createNewModuleTemplate = (): CurriculumDraftModule => ({
   id: crypto.randomUUID(),
   title: "Untitled Module",
+  description: null,
   lessons: [createNewLessonTemplate()],
 });
 

--- a/apps/admin/src/queries/definitions/mutations.ts
+++ b/apps/admin/src/queries/definitions/mutations.ts
@@ -9,7 +9,12 @@ import {
   type CurriculumDraftLessonForm,
   type LudoBannerSnapshot,
 } from "@ludocode/types";
-import type { ChangeCourseIconRequest, ChangeCourseStatusRequest, ChangeCourseTitleRequest } from "@/queries/mutations/courseMutations";
+import type {
+  ChangeCourseDescriptionRequest,
+  ChangeCourseIconRequest,
+  ChangeCourseStatusRequest,
+  ChangeCourseTitleRequest,
+} from "@/queries/mutations/courseMutations";
 import type { CreateBannerRequest } from "../mutations/bannerMutations";
 
 export const mutations = {
@@ -163,5 +168,18 @@ export const mutations = {
           true,
         ),
     });
+  },
+  changeCourseDescription: (courseId: string) => {
+    return mutationOptions<LudoCourse[], Error, ChangeCourseDescriptionRequest>(
+      {
+        mutationKey: ["changeCourseDescription"],
+        mutationFn: (variables) =>
+          ludoPut<LudoCourse[], ChangeCourseDescriptionRequest>(
+            adminApi.snapshots.byCourseCurriculumDescription(courseId),
+            variables,
+            true,
+          ),
+      },
+    );
   },
 };

--- a/apps/admin/src/queries/mutations/courseMutations.ts
+++ b/apps/admin/src/queries/mutations/courseMutations.ts
@@ -22,6 +22,26 @@ export function useChangeCourseTitle({ courseId }: ChangeCourseTitleArgs) {
   });
 }
 
+type ChangeCourseDescriptionArgs = {
+  courseId: string;
+};
+
+export type ChangeCourseDescriptionRequest = {
+  description: string;
+};
+
+export function useChangeCourseDescription({
+  courseId,
+}: ChangeCourseDescriptionArgs) {
+  const qc = useQueryClient();
+  return useMutation({
+    ...mutations.changeCourseDescription(courseId),
+    onSuccess: (payload: LudoCourse[]) => {
+      qc.setQueryData(qk.courses(), payload);
+    },
+  });
+}
+
 type ChangeCourseIconArgs = {
   courseId: string;
 };

--- a/apps/web/src/features/modules/hub/ModulePage.tsx
+++ b/apps/web/src/features/modules/hub/ModulePage.tsx
@@ -8,6 +8,8 @@ import { ludoNavigation } from "@/constants/ludoNavigation.tsx";
 import { getRouteApi, useRouter } from "@tanstack/react-router";
 import { ModulePath } from "./path/ModulePath.tsx";
 import { ModulePathHeader } from "./path/ModulePathHeader.tsx";
+import { ModuleOverview } from "./overview/ModuleOverview.tsx";
+import { MobileModuleInfo } from "./overview/MobileModuleInfo.tsx";
 import { cn } from "@ludocode/design-system/cn-utils.ts";
 
 type ModulePageProps = {
@@ -50,13 +52,36 @@ export function ModulePage({
   return (
     <div
       className={cn(
-        "py-6 gap-12 lg:gap-20 2xl:gap-40 flex justify-center lg:justify-end",
+        "py-6 gap-12 lg:gap-20 flex justify-center lg:justify-end 2xl:justify-center",
         className,
       )}
     >
-      <div className="w-72 lg:w-80 max-w-full flex flex-col gap-4 lg:gap-6 items-center lg:px-0 min-w-0">
+      {currentModule && (
+        <MobileModuleInfo
+          moduleTitle={currentModule.title}
+          moduleIndex={i + 1}
+          moduleCount={modules.length}
+          completedLessons={completedLessons}
+          totalLessons={lessons.length}
+        />
+      )}
+      <div className="hidden 2xl:block w-90 shrink-0">
+        {currentModule && (
+          <div className="sticky top-6 pb-6">
+            <ModuleOverview
+              moduleTitle={currentModule.title}
+              moduleIndex={i + 1}
+              moduleCount={modules.length}
+              completedLessons={completedLessons}
+              totalLessons={lessons.length}
+            />
+          </div>
+        )}
+      </div>
+      <div className="w-72 lg:w-80 max-w-full flex flex-col gap-4 lg:gap-6 items-center min-w-0">
         {currentModule && (
           <ModulePathHeader
+            className="2xl:hidden"
             moduleTitle={currentModule.title}
             moduleIndex={i + 1}
             moduleCount={modules.length}
@@ -74,7 +99,7 @@ export function ModulePage({
           moduleId={moduleId}
         />
       </div>
-      <div className="hidden lg:block w-90  2xl:w-140 min-w-72 max-w-90 2xl:max-w-140">
+      <div className="hidden lg:block w-90 shrink-0">
         <div className="sticky pb-6 top-6">
           <ModuleNavigator
             currentModuleId={moduleId}

--- a/apps/web/src/features/modules/hub/ModulePage.tsx
+++ b/apps/web/src/features/modules/hub/ModulePage.tsx
@@ -52,7 +52,7 @@ export function ModulePage({
   return (
     <div
       className={cn(
-        "py-6 gap-12 lg:gap-20 flex justify-center lg:justify-end 2xl:justify-center",
+        "py-6 gap-12 lg:gap-20 xl:gap-12 2xl:gap-16 flex justify-center lg:justify-end xl:justify-center",
         className,
       )}
     >
@@ -66,7 +66,7 @@ export function ModulePage({
           totalLessons={lessons.length}
         />
       )}
-      <div className="hidden 2xl:block w-90 shrink-0">
+      <div className="hidden xl:block w-64 2xl:w-80 shrink-0">
         {currentModule && (
           <div className="sticky top-6 pb-6">
             <ModuleOverview
@@ -83,7 +83,7 @@ export function ModulePage({
       <div className="w-72 lg:w-80 max-w-full flex flex-col gap-4 lg:gap-6 items-center min-w-0">
         {currentModule && (
           <ModulePathHeader
-            className="2xl:hidden"
+            className="xl:hidden"
             moduleTitle={currentModule.title}
             moduleIndex={i + 1}
             moduleCount={modules.length}

--- a/apps/web/src/features/modules/hub/ModulePage.tsx
+++ b/apps/web/src/features/modules/hub/ModulePage.tsx
@@ -61,6 +61,7 @@ export function ModulePage({
           moduleTitle={currentModule.title}
           moduleIndex={i + 1}
           moduleCount={modules.length}
+          description={currentModule.description}
           completedLessons={completedLessons}
           totalLessons={lessons.length}
         />
@@ -72,6 +73,7 @@ export function ModulePage({
               moduleTitle={currentModule.title}
               moduleIndex={i + 1}
               moduleCount={modules.length}
+              description={currentModule.description}
               completedLessons={completedLessons}
               totalLessons={lessons.length}
             />

--- a/apps/web/src/features/modules/hub/overview/MobileModuleInfo.tsx
+++ b/apps/web/src/features/modules/hub/overview/MobileModuleInfo.tsx
@@ -8,6 +8,7 @@ type MobileModuleInfoProps = {
   moduleTitle: string;
   moduleIndex: number;
   moduleCount: number;
+  description?: string | null;
   completedLessons: number;
   totalLessons: number;
 };
@@ -16,10 +17,13 @@ export function MobileModuleInfo({
   moduleTitle,
   moduleIndex,
   moduleCount,
+  description,
   completedLessons,
   totalLessons,
 }: MobileModuleInfoProps) {
   const [isOpen, setIsOpen] = useState(false);
+
+  if (!description) return null;
 
   return (
     <>
@@ -45,6 +49,7 @@ export function MobileModuleInfo({
 
         <LudoSlideOver.Content>
           <ModuleOverviewBody
+            description={description}
             completedLessons={completedLessons}
             totalLessons={totalLessons}
           />

--- a/apps/web/src/features/modules/hub/overview/MobileModuleInfo.tsx
+++ b/apps/web/src/features/modules/hub/overview/MobileModuleInfo.tsx
@@ -1,0 +1,55 @@
+import { FloatingMobileTrigger } from "@ludocode/design-system/primitives/FloatingMobileTrigger.tsx";
+import { LudoSlideOver } from "@ludocode/design-system/widgets/ludo-slideover.tsx";
+import { InfoIcon } from "lucide-react";
+import { useState } from "react";
+import { ModuleOverviewBody } from "./ModuleOverview.tsx";
+
+type MobileModuleInfoProps = {
+  moduleTitle: string;
+  moduleIndex: number;
+  moduleCount: number;
+  completedLessons: number;
+  totalLessons: number;
+};
+
+export function MobileModuleInfo({
+  moduleTitle,
+  moduleIndex,
+  moduleCount,
+  completedLessons,
+  totalLessons,
+}: MobileModuleInfoProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <FloatingMobileTrigger
+        side="left"
+        variant="surface"
+        icon={InfoIcon}
+        label="About this module"
+        onClick={() => setIsOpen(true)}
+      />
+
+      <LudoSlideOver open={isOpen} onOpenChange={setIsOpen} side="bottom">
+        <LudoSlideOver.Header onClose={() => setIsOpen(false)}>
+          <div>
+            <p className="text-ludo-white-dim text-[10px] font-semibold uppercase tracking-widest">
+              Module {moduleIndex} of {moduleCount}
+            </p>
+            <p className="text-ludo-white-bright text-base font-bold">
+              {moduleTitle}
+            </p>
+          </div>
+        </LudoSlideOver.Header>
+
+        <LudoSlideOver.Content>
+          <ModuleOverviewBody
+            completedLessons={completedLessons}
+            totalLessons={totalLessons}
+          />
+        </LudoSlideOver.Content>
+      </LudoSlideOver>
+    </>
+  );
+}

--- a/apps/web/src/features/modules/hub/overview/ModuleOverview.tsx
+++ b/apps/web/src/features/modules/hub/overview/ModuleOverview.tsx
@@ -1,25 +1,26 @@
 import { ProgressSummary } from "@ludocode/design-system/primitives/progress-summary.tsx";
 
-const MOCK_MODULE_DESCRIPTION =
-  "Work through the lessons in order to pick up the ideas this module is built on, then put them together in a guided project. Each step unlocks the next one, so you can always drop in where you left off.";
-
 type ModuleOverviewBodyProps = {
+  description?: string | null;
   completedLessons: number;
   totalLessons: number;
 };
 
 export function ModuleOverviewBody({
+  description,
   completedLessons,
   totalLessons,
 }: ModuleOverviewBodyProps) {
   return (
     <div className="flex flex-col gap-5">
-      <p className="text-sm leading-relaxed text-ludo-white-dim">
-        {MOCK_MODULE_DESCRIPTION}
-      </p>
+      {description && (
+        <p className="text-sm leading-relaxed text-ludo-white-dim">
+          {description}
+        </p>
+      )}
 
       <div className="flex flex-col gap-2">
-        <div className="h-px w-full bg-ludo-surface" />
+        {description && <div className="h-px w-full bg-ludo-surface" />}
         <ProgressSummary
           className="w-full"
           variant="col"
@@ -43,6 +44,7 @@ export function ModuleOverview({
   moduleTitle,
   moduleIndex,
   moduleCount,
+  description,
   completedLessons,
   totalLessons,
 }: ModuleOverviewProps) {
@@ -58,6 +60,7 @@ export function ModuleOverview({
       </div>
 
       <ModuleOverviewBody
+        description={description}
         completedLessons={completedLessons}
         totalLessons={totalLessons}
       />

--- a/apps/web/src/features/modules/hub/overview/ModuleOverview.tsx
+++ b/apps/web/src/features/modules/hub/overview/ModuleOverview.tsx
@@ -1,0 +1,66 @@
+import { ProgressSummary } from "@ludocode/design-system/primitives/progress-summary.tsx";
+
+const MOCK_MODULE_DESCRIPTION =
+  "Work through the lessons in order to pick up the ideas this module is built on, then put them together in a guided project. Each step unlocks the next one, so you can always drop in where you left off.";
+
+type ModuleOverviewBodyProps = {
+  completedLessons: number;
+  totalLessons: number;
+};
+
+export function ModuleOverviewBody({
+  completedLessons,
+  totalLessons,
+}: ModuleOverviewBodyProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm leading-relaxed text-ludo-white-dim">
+        {MOCK_MODULE_DESCRIPTION}
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <div className="h-px w-full bg-ludo-surface" />
+        <ProgressSummary
+          className="w-full"
+          variant="col"
+          detailed
+          name="lessons complete"
+          current={completedLessons}
+          total={totalLessons}
+        />
+      </div>
+    </div>
+  );
+}
+
+type ModuleOverviewProps = ModuleOverviewBodyProps & {
+  moduleTitle: string;
+  moduleIndex: number;
+  moduleCount: number;
+};
+
+export function ModuleOverview({
+  moduleTitle,
+  moduleIndex,
+  moduleCount,
+  completedLessons,
+  totalLessons,
+}: ModuleOverviewProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-ludo-accent-muted">
+          Module {moduleIndex} of {moduleCount}
+        </span>
+        <h1 className="text-2xl font-bold leading-tight tracking-tight text-ludo-white-bright">
+          {moduleTitle}
+        </h1>
+      </div>
+
+      <ModuleOverviewBody
+        completedLessons={completedLessons}
+        totalLessons={totalLessons}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/modules/hub/path/ModulePathHeader.tsx
+++ b/apps/web/src/features/modules/hub/path/ModulePathHeader.tsx
@@ -1,9 +1,12 @@
+import { cn } from "@ludocode/design-system/cn-utils.ts";
+
 type ModulePathHeaderProps = {
   moduleTitle: string;
   moduleIndex: number;
   moduleCount: number;
   completedLessons: number;
   totalLessons: number;
+  className?: string;
 };
 
 export function ModulePathHeader({
@@ -12,9 +15,15 @@ export function ModulePathHeader({
   moduleCount,
   completedLessons,
   totalLessons,
+  className,
 }: ModulePathHeaderProps) {
   return (
-    <header className="sticky top-0 z-20 flex w-full flex-col items-center gap-1 bg-ludo-background pb-3 pt-1 text-center">
+    <header
+      className={cn(
+        "sticky top-0 z-20 flex w-full flex-col items-center gap-1 bg-ludo-background pb-3 pt-1 text-center",
+        className,
+      )}
+    >
       <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-ludo-accent-muted">
         Module {moduleIndex} of {moduleCount}
       </span>

--- a/packages/api/api-paths.ts
+++ b/packages/api/api-paths.ts
@@ -73,7 +73,7 @@ export function createApiPaths({
     },
 
     leaderboard: {
-      base: `${BASE}/leaderboard`
+      base: `${BASE}/leaderboard`,
     },
 
     progress: {
@@ -127,7 +127,8 @@ export function createApiPaths({
       byIdPublic: (projectId: string) => `${BASE}/projects/public/${projectId}`,
       like: (projectId: string) => `${BASE}/projects/${projectId}/like`,
       name: (projectId: string) => `${BASE}/projects/${projectId}/name`,
-      description: (projectId: string) => `${BASE}/projects/${projectId}/description`,
+      description: (projectId: string) =>
+        `${BASE}/projects/${projectId}/description`,
       visibility: (projectId: string) =>
         `${BASE}/projects/${projectId}/visibility`,
       duplicate: (projectId: string) =>
@@ -158,6 +159,8 @@ export function createApiPaths({
         `${ADMIN_BASE}/snapshots/${courseId}/icon`,
       byCourseCurriculumTitle: (courseId: string) =>
         `${ADMIN_BASE}/snapshots/${courseId}/title`,
+      byCourseCurriculumDescription: (courseId: string) =>
+        `${ADMIN_BASE}/snapshots/${courseId}/description`,
       byCourse: (courseId: string) => `${ADMIN_BASE}/snapshots/${courseId}`,
     },
 

--- a/packages/design-system/primitives/FloatingMobileTrigger.tsx
+++ b/packages/design-system/primitives/FloatingMobileTrigger.tsx
@@ -1,11 +1,15 @@
 import { cn } from "@ludocode/design-system/cn-utils";
-import { ChevronUpIcon, LayoutListIcon } from "lucide-react";
+import { ChevronUpIcon, LayoutListIcon, type LucideIcon } from "lucide-react";
 
 type FloatingTriggerButtonProps = {
   position?: number;
-  title: string;
+  title?: string;
   chevron?: boolean;
   onClick?: () => void;
+  side?: "left" | "right";
+  variant?: "accent" | "surface";
+  icon?: LucideIcon;
+  label?: string;
 };
 
 export function FloatingMobileTrigger({
@@ -13,22 +17,35 @@ export function FloatingMobileTrigger({
   title,
   onClick,
   chevron,
+  side = "right",
+  variant = "accent",
+  icon: Icon = LayoutListIcon,
+  label,
 }: FloatingTriggerButtonProps) {
+  const iconOnly = !title;
+
   return (
     <button
       type="button"
+      aria-label={label}
       onClick={() => onClick?.()}
       className={cn(
-        "fixed bottom-24 right-4 z-40 lg:hidden",
-        "flex items-center gap-2 px-4 py-2.5 rounded-full",
-        "bg-ludo-accent text-ludo-white-bright shadow-lg shadow-ludo-accent/25",
+        "fixed bottom-24 z-40 lg:hidden",
+        side === "right" ? "right-4" : "left-4",
+        "flex items-center gap-2 rounded-full",
+        iconOnly ? "p-2.5" : "px-4 py-2.5",
+        variant === "accent"
+          ? "bg-ludo-accent text-ludo-white-bright shadow-lg shadow-ludo-accent/25"
+          : "bg-ludo-surface text-ludo-white ring-1 ring-white/10 shadow-lg shadow-black/25",
         "hover:cursor-pointer active:scale-95 transition-transform",
       )}
     >
-      <LayoutListIcon className="w-4 h-4" />
-      <span className="text-sm font-semibold">
-        {position} {title}
-      </span>
+      <Icon className={iconOnly ? "w-5 h-5" : "w-4 h-4"} />
+      {title && (
+        <span className="text-sm font-semibold">
+          {position} {title}
+        </span>
+      )}
       {chevron && <ChevronUpIcon className="w-3.5 h-3.5 opacity-60" />}
     </button>
   );

--- a/packages/types/Catalog/LudoCourse.ts
+++ b/packages/types/Catalog/LudoCourse.ts
@@ -7,7 +7,7 @@ export type LudoCourse = {
   courseStatus?: CourseStatus;
   courseIcon: string;
   codeLanguage?: LanguageKey;
-  description: string;
+  description?: string;
 };
 
 export type CourseType = "COURSE" | "SKILL_PATH";

--- a/packages/types/Catalog/LudoModule.ts
+++ b/packages/types/Catalog/LudoModule.ts
@@ -3,4 +3,5 @@ export type LudoModule = {
     title: string;
     courseId: string;
     orderIndex: number;
+    description?: string;
 }

--- a/packages/types/Curriculum/CurriculumDraftSchema.ts
+++ b/packages/types/Curriculum/CurriculumDraftSchema.ts
@@ -160,6 +160,7 @@ export const curriculumDraftSchema = z.object({
     z.object({
       id: z.string(),
       title: z.string().min(1, "Module title required"),
+      description: z.string().nullable(),
       lessons: z.array(CurriculumDraftNavigatorLessonSchema),
     }),
   ),


### PR DESCRIPTION
## Summary

This PR adds module descriptions and displays them on the module page (left pane on desktop screens, an info drawer on mobile). It also aligns the module path in the center of the page as previously it was offset to the right and looked quite ugly on larger desktop screens. 

Additionally, this PR adds the ability to modify module descriptions and course descriptions in the admin app.