### PR TITLE
refactor: Improve background and popover + markdown UI elements

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -10,7 +10,7 @@
     <style>
       html,
       body {
-        background: #22273e;
+        background: #1a1f33;
         margin: 0;
         height: 100%;
       }

--- a/apps/admin/src/App.css
+++ b/apps/admin/src/App.css
@@ -24,8 +24,8 @@ body {
     background: #1a1f33;
   }
   body {
-    @apply text-foreground;
     background: #1a1f33;
+    color: var(--color-ludo-white);
     overscroll-behavior: none;
     height: 100%;
     overflow: hidden;

--- a/apps/admin/src/App.css
+++ b/apps/admin/src/App.css
@@ -21,11 +21,11 @@ body {
     @apply border-border outline-ring/50;
   }
   html {
-    background: #22273e;
+    background: #1a1f33;
   }
   body {
     @apply text-foreground;
-    background: #22273e;
+    background: #1a1f33;
     overscroll-behavior: none;
     height: 100%;
     overflow: hidden;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -18,7 +18,7 @@
     <style>
       html,
       body {
-        background: #22273e;
+        background: #1a1f33;
         margin: 0;
         height: 100%;
       }

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -29,11 +29,10 @@ body {
     overscroll-behavior: none;
   }
   body {
-    @apply text-foreground;
     background: #1a1f33;
+    color: var(--color-ludo-white);
     height: 100%;
     overflow: hidden;
-    @apply bg-background text-foreground;
   }
 }
 

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -25,12 +25,12 @@ body {
     @apply border-border outline-ring/50;
   }
   html {
-    background: #22273e;
+    background: #1a1f33;
     overscroll-behavior: none;
   }
   body {
     @apply text-foreground;
-    background: #22273e;
+    background: #1a1f33;
     height: 100%;
     overflow: hidden;
     @apply bg-background text-foreground;

--- a/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
+++ b/apps/web/src/features/lesson/guided/GuidedExecutableWorkbench.tsx
@@ -1,5 +1,5 @@
 import { getRouteApi } from "@tanstack/react-router";
-import { useHotkeys, useIsMobile } from "@ludocode/hooks";
+import { useHotkeys } from "@ludocode/hooks";
 import {
   useLessonEvaluation,
   useLessonExercise,
@@ -25,6 +25,7 @@ import { cn } from "@ludocode/design-system/cn-utils";
 import { buildProjectSystemPrompt } from "@ludocode/design-system/widgets/chatbot/chatbotSystemPrompts";
 import { useGuidedExercise } from "@/features/lesson/guided/context/useGuidedExerciseContext.tsx";
 import { GuidedLessonActions } from "./components/GuidedLessonActions";
+import { GuidedProjectFeedbackPopover } from "./components/GuidedProjectFeedbackPopover";
 import { MobileTabs, useMobileTabs } from "@ludocode/design-system/primitives/mobile-tabs"
 import { PaneResizeHandle } from "@/features/project/workbench/components/PaneResizeHandle";
 import { useResizableSidePanes } from "@/features/project/hooks/useResizableSidePanes";
@@ -63,7 +64,6 @@ export function GuidedExecutableWorkbench({
   } = useProjectContext();
   const { runCode, stopCode, outputInfo } = useCodeRunnerContext();
   const runnerFeature = useFeatureEnabledCheck({ feature: "isPistonEnabled" });
-  const isMobile = useIsMobile({});
   const { isDesktop, left, right } = useResizableSidePanes();
   const { isRunning, outputLog } = outputInfo;
 
@@ -79,16 +79,16 @@ export function GuidedExecutableWorkbench({
   }, [currentExercise.id]);
 
   useEffect(() => {
-    if (isMobile) {
+    if (!isDesktop) {
       setMobilePane("instructions");
     }
-  }, [currentExercise.id, isMobile]);
+  }, [currentExercise.id, isDesktop]);
 
   useEffect(() => {
-    if (isMobile && isRunning) {
+    if (!isDesktop && isRunning) {
       setMobilePane("output");
     }
-  }, [isMobile, isRunning, setMobilePane]);
+  }, [isDesktop, isRunning, setMobilePane]);
 
   const systemPrompt = useMemo(
     () => buildProjectSystemPrompt(currentExercise, project),
@@ -254,6 +254,7 @@ export function GuidedExecutableWorkbench({
         currentExercise={currentExercise}
         showBlockOutput={showBlockOutput}
         systemPrompt={systemPrompt}
+        isComplete={isComplete}
         className={cn(
           mobilePane === "instructions" ? "flex-1" : "hidden",
           "transform-none transition-none animate-none",
@@ -278,6 +279,7 @@ export function GuidedExecutableWorkbench({
         isEditorReadOnly={isEditorReadOnly}
         canReset={canReset}
         onReset={onReset}
+        showFeedback={isDesktop}
         solutionHint={
           showSolutionHint
             ? {
@@ -332,7 +334,16 @@ export function GuidedExecutableWorkbench({
         style={right.style}
       />
 
-      <div className="lg:hidden border-t border-ludo-surface">
+      <div className="lg:hidden border-t border-ludo-surface bg-ludo-background">
+        {!isDesktop && (
+          <GuidedProjectFeedbackPopover
+            layout="inline"
+            showCorrectFeedback={isComplete}
+            showIncorrectFeedback={isIncorrect}
+            incorrectFeedbackMessage={incorrectFeedbackMessage}
+            onDismissIncorrectFeedback={dismissIncorrectFeedback}
+          />
+        )}
         <div className="px-4 py-2">
           <MobileTabs
             value={mobilePane}
@@ -343,7 +354,7 @@ export function GuidedExecutableWorkbench({
             <MobileTabs.Tab value="output">Output</MobileTabs.Tab>
           </MobileTabs>
         </div>
-        <div className="px-4 w-full flex items-center justify-between gap-2 pb-3 pt-1">
+        <div className="px-4 w-full flex items-center gap-3 pb-4 pt-1">
           <GuidedLessonActions
             canGoBack={canGoBack}
             onGoBack={onGoBack}

--- a/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedExerciseEditorPane.tsx
@@ -25,6 +25,7 @@ type GuidedExerciseEditorPaneProps = {
   isEditorReadOnly: boolean;
   canReset: boolean;
   onReset: () => void;
+  showFeedback: boolean;
   solutionHint?: SolutionHint | null;
   children: ReactNode;
   className?: string;
@@ -39,14 +40,15 @@ export function GuidedExerciseEditorPane({
   isEditorReadOnly,
   canReset,
   onReset,
+  showFeedback,
   solutionHint,
   children,
   className,
 }: GuidedExerciseEditorPaneProps) {
   const { files, current, setCurrent } = useProjectContext();
 
-  const showCorrectFeedback = isComplete;
-  const showIncorrectFeedback = isIncorrect;
+  const showCorrectFeedback = showFeedback && isComplete;
+  const showIncorrectFeedback = showFeedback && isIncorrect;
 
   return (
     <Workbench.Pane
@@ -71,12 +73,15 @@ export function GuidedExerciseEditorPane({
           })}
         </LudoTab.Group>
         <div className="flex items-center gap-2 lg:hidden ml-auto">
-          {solutionHint && <SolutionHintDialog {...solutionHint} />}
+          {solutionHint && (
+            <SolutionHintDialog {...solutionHint} triggerClassName="h-9 w-9" />
+          )}
           <button
             type="button"
             disabled={!canReset}
             onClick={onReset}
-            className="h-10 w-10 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors disabled:opacity-40 disabled:pointer-events-none"
+            className="h-9 w-9 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors disabled:opacity-40 disabled:pointer-events-none"
+            aria-label="Reset code"
             title="Reset code"
           >
             <RotateCcwIcon className="h-4 w-4" />
@@ -89,16 +94,14 @@ export function GuidedExerciseEditorPane({
         readOnly={isEditorReadOnly}
       />
 
-      {(showCorrectFeedback || showIncorrectFeedback) && (
-        <GuidedProjectFeedbackPopover
-          showCorrectFeedback={showCorrectFeedback}
-          showIncorrectFeedback={showIncorrectFeedback}
-          incorrectFeedbackMessage={incorrectFeedbackMessage}
-          onDismissIncorrectFeedback={onDismissIncorrectFeedback}
-        />
-      )}
+      <GuidedProjectFeedbackPopover
+        showCorrectFeedback={showCorrectFeedback}
+        showIncorrectFeedback={showIncorrectFeedback}
+        incorrectFeedbackMessage={incorrectFeedbackMessage}
+        onDismissIncorrectFeedback={onDismissIncorrectFeedback}
+      />
 
-      <div className="absolute bottom-16 lg:bottom-10 w-full px-6 lg:px-10 z-10 hidden lg:flex items-center justify-between gap-2">
+      <div className="absolute bottom-16 lg:bottom-10 w-full px-6 lg:px-10 z-10 hidden lg:flex items-center justify-between gap-3">
         {children}
       </div>
     </Workbench.Pane>

--- a/apps/web/src/features/lesson/guided/components/GuidedExerciseTreePane.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedExerciseTreePane.tsx
@@ -4,12 +4,14 @@ import type { LudoExercise } from "@ludocode/types";
 import { cn } from "@ludocode/design-system/cn-utils";
 import { useIsMobile } from "@ludocode/hooks";
 import { testIds } from "@ludocode/util/test-ids";
+import { CheckIcon, ListChecksIcon } from "lucide-react";
 import type { CSSProperties } from "react";
 
 type GuidedExerciseTreePaneProps = {
   showBlockOutput?: boolean;
   currentExercise: LudoExercise;
   systemPrompt: string;
+  isComplete?: boolean;
   className?: string;
   style?: CSSProperties;
 };
@@ -17,13 +19,12 @@ type GuidedExerciseTreePaneProps = {
 export function GuidedExerciseTreePane({
   showBlockOutput = true,
   currentExercise,
+  isComplete = false,
   className,
   style,
 }: GuidedExerciseTreePaneProps) {
   const isMobile = useIsMobile({});
-  const instructionBlocks = currentExercise.blocks.filter(
-    (block) => block.type === "instructions",
-  );
+  const blocks = currentExercise.blocks;
 
   return (
     <Workbench.Pane
@@ -34,30 +35,52 @@ export function GuidedExerciseTreePane({
       <Workbench.Pane.Winbar className="hidden lg:block">
         <p className="text-sm font-medium tracking-wide">Learn</p>
       </Workbench.Pane.Winbar>
-      <Workbench.Pane.Content>
-        <div className="w-full px-2 pb-4 overflow-y-auto scrollbar-ludo-accent">
-          {instructionBlocks.length > 0 && (
-            <section className="mt-2 w-full rounded-xl border border-ludo-border bg-ludo-surface/40 p-4 lg:p-5">
-              <div className="mb-4 flex items-center justify-between gap-3 border-b border-ludo-border/60 pb-3">
-                <p className="text-[11px] font-bold tracking-[0.14em] uppercase text-ludo-accent-muted">
-                  Exercise Instructions
-                </p>
-              </div>
+      <Workbench.Pane.Content className="px-3 lg:pr-3 scrollbar-ludo-accent">
+        {blocks.length > 0 && (
+          <section
+            className={cn(
+              "w-full shrink-0 rounded-xl border bg-ludo-surface/25 p-4 lg:p-5 transition-colors duration-200",
+              isComplete ? "border-ludo-correct" : "border-ludo-border",
+            )}
+          >
+            <div className="mb-4 flex items-center gap-2.5 border-b border-ludo-border/60 pb-3">
+              <span
+                className={cn(
+                  "flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
+                  isComplete
+                    ? "bg-ludo-success/15 text-ludo-success"
+                    : "bg-ludo-surface text-ludo-accent-muted",
+                )}
+              >
+                {isComplete ? (
+                  <CheckIcon className="h-3.5 w-3.5" strokeWidth={3} />
+                ) : (
+                  <ListChecksIcon className="h-3.5 w-3.5" />
+                )}
+              </span>
+              <p
+                className={cn(
+                  "text-[11px] font-bold tracking-[0.14em] uppercase",
+                  isComplete ? "text-ludo-success" : "text-ludo-accent-muted",
+                )}
+              >
+                {isComplete ? "Task Complete" : "Your Task"}
+              </p>
+            </div>
 
-              <div className="flex flex-col gap-4 items-start">
-                {instructionBlocks.map((block, index) => (
-                  <BlockRenderer
-                    key={`instruction-${index}`}
-                    lessonType="GUIDED"
-                    block={block}
-                    showOutput={showBlockOutput}
-                    mobile={isMobile}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
+            <div className="flex flex-col gap-4 items-start">
+              {blocks.map((block, index) => (
+                <BlockRenderer
+                  key={`block-${index}`}
+                  lessonType="GUIDED"
+                  block={block}
+                  showOutput={showBlockOutput}
+                  mobile={isMobile}
+                />
+              ))}
+            </div>
+          </section>
+        )}
       </Workbench.Pane.Content>
     </Workbench.Pane>
   );

--- a/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedLessonActions.tsx
@@ -1,5 +1,11 @@
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
-import { RotateCcwIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  ChevronLeftIcon,
+  PlayIcon,
+  RotateCcwIcon,
+  SquareIcon,
+} from "lucide-react";
 import { cn } from "@ludocode/design-system/cn-utils";
 import { SolutionHintDialog } from "./SolutionHintDialog";
 import { testIds } from "@ludocode/util/test-ids";
@@ -47,18 +53,22 @@ export function GuidedLessonActions({
         ? "RETRY"
         : "SUBMIT";
 
+  const SubmitIcon = isComplete && !isRunning ? ArrowRightIcon : null;
+
   return (
     <>
-      <div className="flex gap-4 items-center h-10">
+      <div className="flex gap-2 items-center">
         <LudoButton
           type="button"
           variant="default"
           shadow={false}
           disabled={!canGoBack}
           onClick={onGoBack}
-          className="h-10 px-4"
+          aria-label="Previous exercise"
+          className="h-11 lg:h-10 w-11 lg:w-auto lg:px-4 lg:gap-2 text-sm font-bold"
         >
-          BACK
+          <ChevronLeftIcon className="h-4 w-4" strokeWidth={2.5} />
+          <span className="hidden lg:inline">BACK</span>
         </LudoButton>
 
         <LudoButton
@@ -67,35 +77,47 @@ export function GuidedLessonActions({
           shadow={false}
           disabled={!canReset}
           onClick={onReset}
-          className="h-10 px-4 hidden lg:flex"
+          aria-label="Reset code"
+          className="h-10 w-10 px-0 hidden lg:flex"
         >
           <RotateCcwIcon className="h-4 w-4" />
         </LudoButton>
       </div>
-      <div className="h-10 flex items-center gap-2">
+
+      <div className="flex flex-1 items-center justify-end gap-2 lg:flex-none">
         <div className="hidden lg:block">
           {solutionHint && <SolutionHintDialog {...solutionHint} />}
         </div>
+
         <LudoButton
           onClick={runOnly}
-          variant={isRunning ? "default" : "alt"}
-          shadow={false}
+          variant="default"
           disabled={runDisabled}
-          className={cn("h-10 py-0.5 lg:px-4 min-w-20 lg:min-w-24")}
+          className={cn(
+            "h-11 lg:h-10 w-auto px-4 lg:px-5 gap-2 text-sm font-bold",
+          )}
         >
-          {isRunning ? "STOP" : "RUN"}
+          {isRunning ? (
+            <SquareIcon className="h-3.5 w-3.5 fill-current" />
+          ) : (
+            <PlayIcon className="h-3.5 w-3.5 fill-current" />
+          )}
+          <span>{isRunning ? "STOP" : "RUN"}</span>
         </LudoButton>
+
         <LudoButton
           data-testid={testIds.guided.runCodeButton}
           onClick={runOrAdvance}
-          variant={isRunning ? "default" : "alt"}
-          shadow={false}
+          variant="alt"
           disabled={submitDisabled}
-          className={cn("h-10 py-0.5 lg:px-4 min-w-24 lg:min-w-34")}
+          className={cn(
+            "h-11 lg:h-10 flex-1 lg:flex-none min-w-28 lg:min-w-36 lg:w-auto px-4 lg:px-5 gap-2 text-sm font-bold",
+          )}
         >
           <span data-testid={testIds.guided.runCodeButtonText}>
             {submitLabel}
           </span>
+          {SubmitIcon && <SubmitIcon className="h-4 w-4" strokeWidth={2.5} />}
         </LudoButton>
       </div>
     </>

--- a/apps/web/src/features/lesson/guided/components/GuidedProjectFeedbackPopover.tsx
+++ b/apps/web/src/features/lesson/guided/components/GuidedProjectFeedbackPopover.tsx
@@ -1,12 +1,14 @@
 import { cn } from "@ludocode/design-system/cn-utils";
-import { X } from "lucide-react";
+import { CheckIcon, X } from "lucide-react";
 import { testIds } from "@ludocode/util/test-ids";
+import { AnimatePresence, motion } from "motion/react";
 
 type GuidedProjectFeedbackPopoverProps = {
   incorrectFeedbackMessage: string | null;
   onDismissIncorrectFeedback: () => void;
   showCorrectFeedback: boolean;
   showIncorrectFeedback: boolean;
+  layout?: "floating" | "inline";
 };
 
 export function GuidedProjectFeedbackPopover({
@@ -14,36 +16,75 @@ export function GuidedProjectFeedbackPopover({
   onDismissIncorrectFeedback,
   showCorrectFeedback,
   showIncorrectFeedback,
+  layout = "floating",
 }: GuidedProjectFeedbackPopoverProps) {
+  const isVisible = showCorrectFeedback || showIncorrectFeedback;
+
   return (
-    <div
-      data-testid={
-        showCorrectFeedback
-          ? testIds.guided.feedbackCorrect
-          : testIds.guided.feedbackIncorrect
-      }
-      className={cn(
-        "absolute z-10 bottom-4 lg:bottom-22 left-4 lg:right-10 lg:left-auto min-w-56 max-w-80 rounded-md border bg-ludo-background px-3 py-2",
-        showCorrectFeedback ? "border-ludo-correct" : "border-ludo-incorrect",
-      )}
-    >
-      <div className="flex justify-between items-center gap-3">
-        <p className="text-sm text-ludo-white-bright">
-          {showCorrectFeedback
-            ? "Great work!"
-            : (incorrectFeedbackMessage ?? "Not quite!")}
-        </p>
-        {showIncorrectFeedback && (
-          <button
-            type="button"
-            onClick={onDismissIncorrectFeedback}
-            className="rounded p-1 text-ludo-white/70 hover:text-ludo-white hover:bg-ludo-background"
-            aria-label="Close feedback"
+    <AnimatePresence initial={false}>
+      {isVisible && (
+        <motion.div
+          key="guided-feedback"
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 8 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+          role="status"
+          aria-live="polite"
+          data-testid={
+            showCorrectFeedback
+              ? testIds.guided.feedbackCorrect
+              : testIds.guided.feedbackIncorrect
+          }
+          className={cn(
+            "flex items-start gap-3 rounded-xl border-2 bg-ludo-background px-3.5 py-3",
+            showCorrectFeedback
+              ? "border-ludo-correct"
+              : "border-ludo-incorrect",
+            layout === "floating"
+              ? "absolute z-10 bottom-3 left-3 right-3 lg:left-auto lg:right-10 lg:bottom-24 lg:w-80"
+              : "mx-4 mt-3",
+          )}
+        >
+          <span
+            className={cn(
+              "mt-px flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
+              showCorrectFeedback
+                ? "bg-ludo-success/15 text-ludo-success"
+                : "bg-ludo-danger/20 text-ludo-danger",
+            )}
           >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        )}
-      </div>
-    </div>
+            {showCorrectFeedback ? (
+              <CheckIcon className="h-3.5 w-3.5" strokeWidth={3} />
+            ) : (
+              <X className="h-3.5 w-3.5" strokeWidth={3} />
+            )}
+          </span>
+
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-ludo-white-bright">
+              {showCorrectFeedback ? "Great work!" : "Not quite"}
+            </p>
+            <p className="mt-0.5 text-xs leading-relaxed text-ludo-white">
+              {showCorrectFeedback
+                ? "Every check passed — keep going."
+                : (incorrectFeedbackMessage ??
+                  "Take another look at your code and try again.")}
+            </p>
+          </div>
+
+          {showIncorrectFeedback && (
+            <button
+              type="button"
+              onClick={onDismissIncorrectFeedback}
+              className="-mr-1 -mt-1 shrink-0 rounded-md p-1.5 text-ludo-white-dim hover:cursor-pointer hover:bg-ludo-surface hover:text-ludo-white-bright transition-colors"
+              aria-label="Close feedback"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/apps/web/src/features/lesson/guided/components/SolutionHintDialog.tsx
+++ b/apps/web/src/features/lesson/guided/components/SolutionHintDialog.tsx
@@ -1,4 +1,5 @@
 import { DiffEditor } from "@monaco-editor/react";
+import { cn } from "@ludocode/design-system/cn-utils";
 import { LudoButton } from "@ludocode/design-system/primitives/ludo-button";
 import { LudoDialog } from "@ludocode/design-system/widgets/ludo-dialog";
 import { DialogTitle } from "@ludocode/external/ui/dialog";
@@ -12,6 +13,7 @@ type SolutionHintDialogProps = {
   solution: string;
   languageId: string;
   onApplySolution: () => void;
+  triggerClassName?: string;
 };
 
 export function SolutionHintDialog({
@@ -19,6 +21,7 @@ export function SolutionHintDialog({
   solution,
   languageId,
   onApplySolution,
+  triggerClassName,
 }: SolutionHintDialogProps) {
   const [open, setOpen] = useState(false);
   const isMobile = useIsMobile({});
@@ -37,10 +40,14 @@ export function SolutionHintDialog({
       trigger={
         <button
           type="button"
-          className="h-10 hover:cursor-pointer w-10 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-white-bright transition-colors"
+          className={cn(
+            "h-10 hover:cursor-pointer w-10 flex items-center justify-center rounded-md bg-ludo-surface hover:bg-ludo-surface-hover text-ludo-amber-alt transition-colors",
+            triggerClassName,
+          )}
+          aria-label="View reference solution"
           title="View reference solution"
         >
-          <LightbulbIcon className="h-5 w-5" />
+          <LightbulbIcon className="h-4.5 w-4.5" />
         </button>
       }
     >

--- a/apps/web/src/features/modules/hub/path/PathPopover.tsx
+++ b/apps/web/src/features/modules/hub/path/PathPopover.tsx
@@ -11,6 +11,7 @@ import { LudoPopover } from "@ludocode/design-system/widgets/ludo-popover.tsx";
 import type { LessonStatus, LudoLesson } from "@ludocode/types";
 import { PopoverClose } from "@radix-ui/react-popover";
 import { testIds } from "@ludocode/util/test-ids";
+import { cn } from "@ludocode/design-system/cn-utils.ts";
 
 type PathPopoverProps = {
   trigger: ReactElement;
@@ -22,33 +23,33 @@ type PathPopoverProps = {
 const popoverConfig: Record<
   LessonStatus,
   {
+    status: string;
     text: string;
-    variant: "default" | "alt" | "danger";
     icon: typeof PlayIcon;
     disabled: boolean;
   }
 > = {
   LOCKED: {
+    status: "Locked",
     text: "Locked",
-    variant: "default",
     icon: LockIcon,
     disabled: true,
   },
   MASTERED: {
+    status: "Completed",
     text: "Review",
-    variant: "default",
     icon: RotateCcwIcon,
     disabled: false,
   },
   COMPLETE: {
+    status: "Completed",
     text: "Master",
-    variant: "default",
     icon: StarIcon,
     disabled: false,
   },
   DEFAULT: {
+    status: "Current lesson",
     text: "Start",
-    variant: "default",
     icon: PlayIcon,
     disabled: false,
   },
@@ -64,34 +65,43 @@ export function PathPopover({
   const Icon = config.icon;
 
   return (
-    <LudoPopover trigger={trigger} className="flex-col gap-3 min-w-72">
-      <div className="flex items-start justify-between gap-3">
+    <LudoPopover trigger={trigger} className="gap-3">
+      <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-0.5 min-w-0">
+          <span
+            className={cn(
+              "text-[10px] font-semibold uppercase tracking-widest",
+              config.disabled
+                ? "text-ludo-white-dim"
+                : "text-ludo-accent-muted",
+            )}
+          >
+            {config.status}
+          </span>
           <p className="text-sm font-bold text-ludo-white-bright leading-snug">
             {lesson.title}
           </p>
-          {/* <p className="text-xs text-ludo-white leading-relaxed">
-            Learn how to use Python to print text to the console!
-          </p> */}
         </div>
         <PopoverClose asChild>
           <button
             type="button"
             aria-label="Close"
-            className="shrink-0 rounded-md p-1 text-ludo-white hover:text-ludo-white-bright hover:bg-ludo-surface transition-colors"
+            className="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-ludo-white-dim hover:text-ludo-white-bright hover:bg-white/10 transition-colors"
           >
             <XIcon className="h-3.5 w-3.5" />
           </button>
         </PopoverClose>
       </div>
 
-      {/* Action */}
       <PopoverClose asChild>
         <LudoButton
           data-testid={testIds.path.popoverButton(lesson.id)}
           onClick={() => goToLesson()}
-          className="h-9 w-full rounded-lg text-sm font-semibold gap-2"
-          variant={config.variant}
+          className={cn(
+            "h-9 w-full rounded-lg text-sm font-semibold gap-2",
+            config.disabled && "bg-white/8 text-ludo-white-dim",
+          )}
+          variant="alt"
           shadow={!config.disabled}
           disabled={config.disabled}
         >

--- a/apps/web/src/features/project/hooks/useMonacoTheme.tsx
+++ b/apps/web/src/features/project/hooks/useMonacoTheme.tsx
@@ -9,8 +9,8 @@ export function useMonacoTheme() {
       inherit: true,
       rules: [],
       colors: {
-        "editor.background": "#22273E",
-        "editorGutter.background": "#22273E",
+        "editor.background": "#1A1F33",
+        "editorGutter.background": "#1A1F33",
       },
     });
   };

--- a/packages/design-system/primitives/mobile-tabs.tsx
+++ b/packages/design-system/primitives/mobile-tabs.tsx
@@ -44,7 +44,12 @@ function MobileTabsRoot({
 
   return (
     <MobileTabsContext.Provider value={contextValue}>
-      <div className={cn("flex items-center justify-between gap-2", className)}>
+      <div
+        className={cn(
+          "flex items-center justify-between gap-1 rounded-lg bg-ludo-surface/25 p-1",
+          className,
+        )}
+      >
         {children}
       </div>
     </MobileTabsContext.Provider>
@@ -55,7 +60,7 @@ function MobileTabsTab({
   value,
   className,
   activeClassName = "bg-ludo-surface text-ludo-white-bright",
-  inactiveClassName = "bg-transparent text-ludo-white/90",
+  inactiveClassName = "bg-transparent text-ludo-white/80 hover:text-ludo-white-bright",
   badge,
   children,
 }: MobileTabsTabProps) {
@@ -71,7 +76,7 @@ function MobileTabsTab({
       type="button"
       onClick={() => ctx.onValueChange(value)}
       className={cn(
-        "relative h-8 rounded-md px-3 flex-1 text-sm font-semibold",
+        "relative h-8 rounded-md px-3 flex-1 text-sm font-semibold transition-colors",
         isActive ? activeClassName : inactiveClassName,
         className,
       )}

--- a/packages/design-system/styles/theme/chatbot.css
+++ b/packages/design-system/styles/theme/chatbot.css
@@ -40,7 +40,7 @@
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
-  --border: #22273e;
+  --border: #1a1f33;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -76,7 +76,7 @@
 
 .chatbot-content pre {
   padding: 12px;
-  background: #22273e !important;
+  background: #1a1f33 !important;
   border: 1px solid #2a304f !important;
   border-radius: 0px !important;
   white-space: pre-wrap !important;

--- a/packages/design-system/styles/theme/ludo.css
+++ b/packages/design-system/styles/theme/ludo.css
@@ -1,6 +1,6 @@
 @theme {
   /* == BACKGROUND == */
-  --color-ludo-background: #22273e;
+  --color-ludo-background: #1a1f33;
 
   /* == SURFACE == */
   --color-ludo-surface: #303966;

--- a/packages/design-system/widgets/exercise/BlockRenderer.tsx
+++ b/packages/design-system/widgets/exercise/BlockRenderer.tsx
@@ -46,7 +46,14 @@ export function BlockRenderer({
   switch (block.type) {
     case "header":
       return (
-        <h2 className="text-ludo-white-bright text-center text-lg sm:text-xl lg:max-w-xl font-semibold leading-snug">
+        <h2
+          className={cn(
+            "text-ludo-white-bright font-semibold leading-snug",
+            lessonType == "NORMAL"
+              ? "text-center text-lg sm:text-xl lg:max-w-xl"
+              : "w-full text-start text-base sm:text-lg",
+          )}
+        >
           <ReactMarkdown components={headerComponents}>
             {block.content}
           </ReactMarkdown>
@@ -87,18 +94,23 @@ export function BlockRenderer({
       return <ExerciseMedia media={block.src} />;
     case "instructions":
       return (
-        <div className="flex flex-col gap-2 w-full lg:max-w-xl">
+        <ol className="flex flex-col gap-2 w-full lg:max-w-xl">
           {block.instructions.map((step, idx) => (
-            <div key={idx} className="flex w-full items-start gap-2">
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center text-ludo-white-bright">
-                <span className="h-1 w-1 rounded-full bg-current" />
+            <li
+              key={idx}
+              className="flex w-full items-start gap-3 rounded-lg bg-ludo-background/50 px-3 py-2.5"
+            >
+              <span className="mt-px flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-ludo-surface text-[11px] font-bold tabular-nums text-ludo-accent-muted">
+                {idx + 1}
               </span>
-              <p className="min-w-0 flex-1 text-left text-sm leading-relaxed text-ludo-white">
-                {step}
-              </p>
-            </div>
+              <div className="min-w-0 flex-1 text-left text-sm leading-relaxed text-ludo-white-bright/90">
+                <ReactMarkdown components={paragraphComponents}>
+                  {step}
+                </ReactMarkdown>
+              </div>
+            </li>
           ))}
-        </div>
+        </ol>
       );
     default:
       return null;

--- a/packages/design-system/widgets/ludo-popover.tsx
+++ b/packages/design-system/widgets/ludo-popover.tsx
@@ -20,16 +20,15 @@ export function LudoPopover({
       <PopoverContent
         align={"center"}
         side="bottom"
+        sideOffset={10}
+        collisionPadding={16}
         className={cn(
-          "rounded-xl relative mx-10 flex justify-between pt-3 min-w-80 flex-row mt-2 bg-ludo-background border-2 border-ludo-accent",
+          "relative flex w-72 flex-col rounded-xl p-3",
+          "bg-ludo-surface border border-white/10 shadow-lg shadow-black/30",
           className,
         )}
       >
-        <PopoverArrow
-          className="fill-ludo-surface stroke-ludo-accent"
-          width={12}
-          height={6}
-        />
+        <PopoverArrow className="fill-ludo-surface" width={14} height={7} />
         {children}
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## Summary
This PR improves the UI for popovers and guided lessons. It also darkens the `ludo-background` color to provide more contrast between page elements and the background.

## Changes
- Changed `ludo-background` to `1a1f33`
- Added nicer style for `PathPopover`
- Added `GuidedProjectFeedbackPopover` to replace old popover on guided projects, it also looks nicer now
- Made the markdown instructions nicer on the guided projects and changed `BlockRenderer` 

## Keywords

Rabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Guided exercises now show completion status for all exercise sections.
  - Added clearer success and error feedback on desktop and mobile.
  - Improved lesson navigation, action controls, solution hints, and exercise instructions.
  - Lesson status popovers now provide clearer state labels and actions.

- **Style**
  - Refined responsive layouts, mobile tabs, buttons, popovers, and instruction cards.
  - Updated backgrounds and editor colors for a deeper, more consistent theme.
  - Improved accessibility labels, icons, spacing, and visual feedback states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->