### PR TITLE
feat: Add keybindings for SELECT exercise options

### DIFF
--- a/apps/web/src/features/lesson/components/ExerciseInteraction.tsx
+++ b/apps/web/src/features/lesson/components/ExerciseInteraction.tsx
@@ -5,7 +5,7 @@ import type { AnswerToken } from "@ludocode/types";
 import { useIsMobile } from "@ludocode/hooks";
 import { LudoCodePreview } from "@ludocode/design-system/widgets/ludo-code-preview.tsx";
 import { LudoOption } from "@ludocode/design-system/primitives/ludo-option.tsx";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 
 export type OptionLayout = "ROW" | "COLUMN";
 export type SelectionMode = "APPEND" | "REPLACE";
@@ -56,6 +56,26 @@ export function ExerciseInteraction({
   const optionsLayout: OptionLayout =
     exerciseType == "CLOZE" ? "ROW" : "COLUMN";
 
+  useEffect(() => {
+    if (optionsLayout !== "COLUMN") return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest("input, textarea, [contenteditable]")
+      )
+        return;
+
+      const option = options[Number(event.key) - 1];
+      if (!option) return;
+
+      replaceAnswerAt(0, { id: option.id, value: option.content });
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [optionsLayout, options, replaceAnswerAt]);
+
   return (
     <div
       className={cn("flex flex-col w-full items-center justify-start gap-8")}
@@ -89,7 +109,7 @@ export function ExerciseInteraction({
       )}
 
       <OptionListWrapper className="lg:max-w-xl max-w-xl" type={optionsLayout}>
-        {options.map((option) => {
+        {options.map((option, idx) => {
           const isSelected =
             currentExerciseInputs.find((t) => t.id === option.id) != null;
 
@@ -100,6 +120,7 @@ export function ExerciseInteraction({
                 variant="pill"
                 enabled={!isSelected}
                 content={option.content}
+                index={idx}
                 isSelected={isSelected}
                 onSelect={() =>
                   handleSelect({ id: option.id, value: option.content })
@@ -117,6 +138,7 @@ export function ExerciseInteraction({
                 isComplete ? "CORRECT" : isIncorrect ? "INCORRECT" : "DEFAULT"
               }
               option={option}
+              index={idx}
               userSelections={currentExerciseInputs}
               setAnswerAt={replaceAnswerAt}
             />

--- a/packages/design-system/primitives/ludo-option.tsx
+++ b/packages/design-system/primitives/ludo-option.tsx
@@ -15,6 +15,7 @@ type PillProps = BaseProps & {
   content: string;
   isSelected: boolean;
   onSelect: () => void;
+  index: number;
   testId?: string;
 };
 
@@ -23,6 +24,7 @@ type WideSingleSelectProps = BaseProps & {
   option: { id: string; content: string };
   userSelections: AnswerToken[];
   setAnswerAt: (index: number, value: AnswerToken) => void;
+  index: number;
   testId?: string;
 };
 
@@ -72,8 +74,8 @@ export function LudoOption(props: LudoOptionProps) {
       }
       onClick={handleClick}
       className={cn(
-        "py-2.5 px-5 code rounded-xl lg:transition-all lg:active:translate-y-[3px] lg:duration-100 transition-[transform] duration-100 transform-gpu will-change-transform touch-action-manipulation select-none",
-        isWide && "w-full",
+        "relative py-2.5 px-5 code rounded-xl lg:transition-all lg:active:translate-y-[3px] lg:duration-100 transition-[transform] duration-100 transform-gpu will-change-transform touch-action-manipulation select-none",
+        isWide && "w-full px-12",
         "hover:cursor-pointer active:shadow-none",
         isSelected
           ? isWide
@@ -85,6 +87,11 @@ export function LudoOption(props: LudoOptionProps) {
         isWide ? "text-center text-ludo-white-bright" : "text-md",
       )}
     >
+      {isWide && (
+        <span className="absolute left-3 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md bg-white/8 text-[11px] text-ludo-white-dim">
+          {props.index + 1}
+        </span>
+      )}
       {content}
     </button>
   );


### PR DESCRIPTION
## Summary
This PR adds keybindings for selecting options in exercises of the `SELECT` type (i.e. multiple choice)

It uses a `useEffect` hook that listens for the key input and uses the index of the option to know which one to select.

Options now also have a number representing the keybinding associated with them.

## Screenshots

<img width="650" height="355" alt="image" src="https://github.com/user-attachments/assets/201b1493-6fa3-436e-868b-919c92d0d302" />


## Keywords

Rabbit